### PR TITLE
Fix module packaging

### DIFF
--- a/src/fontawesome.module.ts
+++ b/src/fontawesome.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { FaIconComponent } from './icon';
-import { FaLayersComponent, FaLayersTextComponent, FaLayersCounterComponent } from './layers';
+import { FaIconComponent } from './icon/icon.component';
+import { FaLayersComponent } from './layers/layers.component';
+import { FaLayersTextComponent } from './layers/layers-text.component';
+import { FaLayersCounterComponent } from './layers/layers-counter.component';
 
 @NgModule({
   imports: [CommonModule],

--- a/src/icon/icon.component.ts
+++ b/src/icon/icon.component.ts
@@ -22,9 +22,13 @@ import {
 } from '@fortawesome/fontawesome-svg-core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
-import { faNotFoundIconHtml, faWarnIfIconHtmlMissing, faWarnIfIconSpecMissing} from '../shared/errors';
-import { objectWithKey, faClassList, faNormalizeIconSpec } from '../shared/utils';
-import { FaProps } from '../shared/models';
+import { faNormalizeIconSpec } from '../shared/utils/normalize-icon-spec.util';
+import { FaProps } from '../shared/models/props.model';
+import { objectWithKey } from '../shared/utils/object-with-keys.util';
+import { faClassList } from '../shared/utils/classlist.util';
+import { faWarnIfIconHtmlMissing } from '../shared/errors/warn-if-icon-html-missing';
+import { faWarnIfIconSpecMissing } from '../shared/errors/warn-if-icon-spec-missing';
+import { faNotFoundIconHtml } from '../shared/errors/not-found-icon-html';
 
 /**
  * Fontawesome icon.

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -1,1 +1,0 @@
-export * from './icon.component';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from './fontawesome.module';
-export { FaProps } from './shared/models';
-export { FaIconComponent } from './icon';
-export { FaLayersComponent, FaLayersTextComponent } from './layers';
+export { FaProps } from './shared/models/props.model';
+export { FaIconComponent } from './icon/icon.component';
+export { FaLayersComponent } from './layers/layers.component';
+export { FaLayersTextComponent } from './layers/layers-text.component';
+export { FaLayersCounterComponent } from './layers/layers-counter.component';

--- a/src/layers/index.ts
+++ b/src/layers/index.ts
@@ -1,3 +1,0 @@
-export * from './layers.component';
-export * from './layers-text.component';
-export * from './layers-counter.component';

--- a/src/layers/layers-text-base.component.ts
+++ b/src/layers/layers-text-base.component.ts
@@ -1,9 +1,9 @@
 import {
   Input,
   Inject,
+  Injectable,
   Optional,
   OnChanges,
-  Component,
   forwardRef,
   HostBinding,
   SimpleChanges
@@ -14,13 +14,11 @@ import {
   TextParams
 } from '@fortawesome/fontawesome-svg-core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { faWarnIfParentNotExist } from '../shared/errors';
-import { FaLayersComponent } from './layers.component';
 
-@Component({
-    selector: 'fa-layers-text-base',
-    template: ''
-})
+import { FaLayersComponent } from './layers.component';
+import { faWarnIfParentNotExist } from '../shared/errors/warn-if-parent-not-exist';
+
+@Injectable()
 export abstract class FaLayersTextBaseComponent implements OnChanges {
 
   constructor(@Inject(forwardRef(() => FaLayersComponent)) @Optional() private parent: FaLayersComponent,

--- a/src/layers/layers-text.component.ts
+++ b/src/layers/layers-text.component.ts
@@ -16,8 +16,9 @@ import {
 } from '@fortawesome/fontawesome-svg-core';
 import { FaLayersTextBaseComponent } from './layers-text-base.component';
 
-import { objectWithKey, faClassList } from '../shared/utils';
-import { FaProps } from '../shared/models';
+import { FaProps } from '../shared/models/props.model';
+import { objectWithKey } from '../shared/utils/object-with-keys.util';
+import { faClassList } from '../shared/utils/classlist.util';
 
 /**
  * Fontawesome layers text.

--- a/src/layers/layers.component.spec.ts
+++ b/src/layers/layers.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { faUser, faMobile } from '@fortawesome/free-solid-svg-icons';
 
-import { FaIconComponent } from '../icon';
+import { FaIconComponent } from '../icon/icon.component';
 import { FaLayersComponent } from './layers.component';
 import { FaLayersTextComponent } from './layers-text.component';
 

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -1,4 +1,0 @@
-export * from './not-found-icon-html';
-export * from './warn-if-parent-not-exist';
-export * from './warn-if-icon-html-missing';
-export * from './warn-if-icon-spec-missing';

--- a/src/shared/models/index.ts
+++ b/src/shared/models/index.ts
@@ -1,1 +1,0 @@
-export * from './props.model';

--- a/src/shared/utils/classlist.util.ts
+++ b/src/shared/utils/classlist.util.ts
@@ -1,4 +1,4 @@
-import { FaProps } from '../models';
+import { FaProps } from '../models/props.model';
 
 /**
  * Fontawesome class list.

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,4 +1,0 @@
-export * from './classlist.util';
-export * from './is-icon-lookup.util';
-export * from './object-with-keys.util';
-export * from './normalize-icon-spec.util';


### PR DESCRIPTION
I tried to use pre-release `0.1.0-7` and add it to a fresh angular-cli app, to make sure everything was working end-to-end, especially to verify that tree shaking is working as expected.

To my surprise `ng build` failed.

And I found some strange gibberish in `angular-fontawesome.d.ts`, which led me to notice that I'd overlooked to add an export for the new counter component.

So the first commit in this PR adds that export.

But still, when I do `ng build --prod`, I get the error:
```
ERROR in : Unexpected value 'undefined' exported by the module 'FontAwesomeModule in /Users/mike/ng-app2/node_modules/@fortawesome/angular-fontawesome/angular-fontawesome.d.ts'
```
@devoto13 or @zeevkatz 
1. Do you know what might be causing that error?
2. This _is_ the way to build an optimized, tree-shaken bundle, right? A production build with `--prod` or `--target=production`?