### PR TITLE
Build fixes and fullTemplateTypeCheck support

### DIFF
--- a/src/icon/icon.component.ts
+++ b/src/icon/icon.component.ts
@@ -43,10 +43,10 @@ import { faNotFoundIconHtml } from '../shared/errors/not-found-icon-html';
 export class FaIconComponent implements OnChanges {
   public icon: Icon;
 
-  constructor(private sanitizer: DomSanitizer) {}
-
   @HostBinding('innerHTML')
-  private renderedIconHTML: SafeHtml;
+  public renderedIconHTML: SafeHtml;
+
+  constructor(private sanitizer: DomSanitizer) {}
 
   private params: IconParams;
   private iconSpec: IconLookup;

--- a/src/icon/icon.component.ts
+++ b/src/icon/icon.component.ts
@@ -35,15 +35,15 @@ import { faNotFoundIconHtml } from '../shared/errors/not-found-icon-html';
  */
 @Component({
   selector: 'fa-icon',
-  template: ``
+  template: ``,
+  host: {
+    class: 'ng-fa-icon',
+  }
 })
 export class FaIconComponent implements OnChanges {
   public icon: Icon;
 
   constructor(private sanitizer: DomSanitizer) {}
-
-  @HostBinding('class.ng-fa-icon')
-  private cssClass = true;
 
   @HostBinding('innerHTML')
   private renderedIconHTML: SafeHtml;

--- a/src/layers/layers-counter.component.ts
+++ b/src/layers/layers-counter.component.ts
@@ -14,12 +14,12 @@ import { FaLayersTextBaseComponent } from './layers-text-base.component';
  */
 @Component({
   selector: 'fa-layers-counter',
-  template: ''
+  template: '',
+  host: {
+    class: 'ng-fa-layers-counter'
+  }
 })
 export class FaLayersCounterComponent extends FaLayersTextBaseComponent {
-
-  @HostBinding('class.ng-fa-layers-counter')
-  private cssClass = true;
 
   /**
    * Updating params by component props.

--- a/src/layers/layers-text-base.component.ts
+++ b/src/layers/layers-text-base.component.ts
@@ -21,14 +21,14 @@ import { faWarnIfParentNotExist } from '../shared/errors/warn-if-parent-not-exis
 @Injectable()
 export abstract class FaLayersTextBaseComponent implements OnChanges {
 
+  @HostBinding('innerHTML')
+  public renderedHTML: SafeHtml;
+
   constructor(@Inject(forwardRef(() => FaLayersComponent)) @Optional() private parent: FaLayersComponent,
     private sanitizer: DomSanitizer) {
 
     faWarnIfParentNotExist(this.parent, 'FaLayersComponent', this.constructor.name);
   }
-
-  @HostBinding('innerHTML')
-  private renderedHTML: SafeHtml;
 
   protected params: TextParams;
 

--- a/src/layers/layers-text.component.ts
+++ b/src/layers/layers-text.component.ts
@@ -25,12 +25,12 @@ import { faClassList } from '../shared/utils/classlist.util';
  */
 @Component({
   selector: 'fa-layers-text',
-  template: ''
+  template: '',
+  host: {
+    class: 'ng-fa-layers-text'
+  }
 })
 export class FaLayersTextComponent extends FaLayersTextBaseComponent {
-
-  @HostBinding('class.ng-fa-layers-text')
-  private cssClass = true;
 
   @Input() private spin?: boolean;
   @Input() private pulse?: boolean;

--- a/src/layers/layers.component.ts
+++ b/src/layers/layers.component.ts
@@ -1,14 +1,15 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component } from '@angular/core';
 
 /**
  * Fontawesome layers.
  */
 @Component({
   selector: 'fa-layers',
-  template: `<ng-content select="fa-icon, fa-layers-text, fa-layers-counter"></ng-content>`
+  template: `<ng-content select="fa-icon, fa-layers-text, fa-layers-counter"></ng-content>`,
+  host: {
+    class: 'fa-layers'
+  }
 })
 export class FaLayersComponent {
-  @HostBinding('class.fa-layers')
-  private cssClass = true;
 }
 

--- a/tasks/rollup-globals.js
+++ b/tasks/rollup-globals.js
@@ -278,4 +278,6 @@ module.exports = {
     'rxjs/symbol/iterator':     'Rx.Symbol',
     'rxjs/symbol/observable':   'Rx.Symbol',
     'rxjs/symbol/rxSubscriber': 'Rx.Symbol',
+
+    '@fortawesome/fontawesome-svg-core': 'fontawesome-svg-core'
   };

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -5,9 +5,11 @@
         "flatModuleOutFile": "angular-fontawesome.js",
         "genDir": "../out-tsc/lib-gen-dir/",
         "strictMetadataEmit": true,
-        "skipTemplateCodegen": true
+        "skipTemplateCodegen": true,
+        "fullTemplateTypeCheck": true
     },
     "compilerOptions": {
+        "rootDir": "build",
         "baseUrl": "",
         "declaration": true,
         "emitDecoratorMetadata": true,

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -5,9 +5,11 @@
         "flatModuleOutFile": "angular-fontawesome.js",
         "genDir": "../out-tsc/lib-gen-dir/",
         "strictMetadataEmit": true,
-        "skipTemplateCodegen": true
+        "skipTemplateCodegen": true,
+        "fullTemplateTypeCheck": true
     },
     "compilerOptions": {
+        "rootDir": "build",
         "baseUrl": "",
         "declaration": true,
         "emitDecoratorMetadata": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "angularCompilerOptions": {
         "strictMetadataEmit": true,
-        "skipTemplateCodegen": true
+        "skipTemplateCodegen": true,
+        "fullTemplateTypeCheck": true
     },
     "compilerOptions": {
         "baseUrl": "",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
     "buildOnSave": false,
+    "angularCompilerOptions": {
+        "fullTemplateTypeCheck": true
+    },
     "compilerOptions": {
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,

--- a/tslint.json
+++ b/tslint.json
@@ -111,7 +111,7 @@
         "component-selector": [true, "element", "fa", "kebab-case"],
         "use-input-property-decorator": true,
         "use-output-property-decorator": true,
-        "use-host-property-decorator": true,
+        "use-host-property-decorator": false,
         "no-input-rename": true,
         "no-output-rename": true,
         "use-life-cycle-interface": true,


### PR DESCRIPTION
1. Ensured that `fontawesome-svg-core` is not inlined in the `angular-fontawesome` bundles, but imported instead. This is more correct behavior. Was this done for the side effect of including license banner? If so, we need to implement this functionality properly in the build pipeline.

2. Added support for `fullTemplateTypeCheck`. Fixes #27.