### PR TITLE
More verbose Icon Library Usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ The icon library provides convenient usage in your templates but you have to man
 the icons separate from your components. This means that if someone
 accidentally removes the icon from the icon library your component which uses it could break.
 
+Icons can be defined once in `app.module` with `library.add()`. Icons defined here will be available to any other component who's parent module also imports `FontAwesomeModule`. This eliminates the need to redefine or explicitly import icons into individual components across multiple modules, lazy-loaded or not.
+
 `src/app/app.component.html`
 
 ```html

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The icon library provides convenient usage in your templates but you have to man
 the icons separate from your components. This means that if someone
 accidentally removes the icon from the icon library your component which uses it could break.
 
-Icons can be defined once in `app.module` with `library.add()`. Icons defined here will be available to any other component who's parent module also imports `FontAwesomeModule`. This eliminates the need to redefine or explicitly import icons into individual components across multiple modules, lazy-loaded or not.
+Icons can be defined once in `app.module` with `library.add()`. Icons defined here will be available to any other component whose parent module also imports `FontAwesomeModule`. This eliminates the need to redefine or explicitly import icons into individual components across multiple modules, lazy-loaded or not.
 
 `src/app/app.component.html`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The icon library provides convenient usage in your templates but you have to man
 the icons separate from your components. This means that if someone
 accidentally removes the icon from the icon library your component which uses it could break.
 
-Icons can be defined once in `app.module` with `library.add()`. Icons defined here will be available to any other component whose parent module also imports `FontAwesomeModule`. This eliminates the need to redefine or explicitly import icons into individual components across multiple modules, lazy-loaded or not.
+Icons can be registered once in `app.module` with `library.add()`. Icons added to the library will be available to any other component whose parent module also imports `FontAwesomeModule`. This eliminates the need to redefine or explicitly import icons into individual components across multiple modules, lazy-loaded or not.
 
 `src/app/app.component.html`
 


### PR DESCRIPTION
Added a paragraph describing further details and benefits of the Icon Library as I understand it to function after playing with it for a bit.
- Icons can be defined once
- .. in `app.module`
- No need to import icons into individual components
- .. but still need to import `FontAwesomeModule` into non-`app.module` modules
- Works with lazy-loaded modules

Hopefully my understanding is correct. If so, these points may be self-evident given the use cases following them, but I thought they may aid in a more complete / verbose understanding when skimming paragraphs before implementing code in larger projects with more than just an `app.module`.