### PR TITLE
Added missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "protractor": "~5.4.0",
     "rimraf": "^2.6.2",
     "ts-node": "~7.0.1",
+    "tsickle": ">=0.27.3",
+    "tslib": "^1.9.0",
     "tslint": "~5.11.0",
     "typescript": "2.9.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6494,7 +6494,7 @@ ts-node@~7.0.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-tsickle@^0.32.1:
+tsickle@>=0.27.3, tsickle@^0.32.1:
   version "0.32.1"
   resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.32.1.tgz#f16e94ba80b32fc9ebe320dc94fbc2ca7f3521a5"
   dependencies:


### PR DESCRIPTION
Fixes warnings on install:

```
warning " > ng-packagr@4.1.1" has unmet peer dependency "tsickle@>=0.27.3".
warning " > ng-packagr@4.1.1" has unmet peer dependency "tslib@^1.9.0".
```

It was not broken before, because these dependencies were installed as a side effect. Adding them explicitly is more safe approach.