### PR TITLE
Setting View Encapsulation to NONE for fa-icon component.

### DIFF
--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -39,7 +39,8 @@ import { FaIconService } from './icon.service';
   template: ``,
   host: {
     class: 'ng-fa-icon',
-  }
+  },
+  encapsulation: ViewEncapsulation.None
 })
 export class FaIconComponent implements OnChanges {
   // tslint:disable-next-line:no-input-rename

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -3,7 +3,8 @@ import {
   OnChanges,
   Component,
   HostBinding,
-  SimpleChanges
+  SimpleChanges,
+  ViewEncapsulation
 } from '@angular/core';
 import {
   icon,


### PR DESCRIPTION
The purpose of this PR is to fix the issue of css classes not applying styles to the svg element. 

If View Encapsulation is not set to NONE,  it's impossible to have external css class styles applied to the SVG element without [ng-deep](https://angular.io/guide/component-styles#deprecated-deep--and-ng-deep)(which is deprecated and will soon not work). By setting view encapsulation to none the font icon component can have styles applied from the parent components styles.


[Documentation on  Angular's View Encapsulation](https://angular.io/api/core/ViewEncapsulation) 