### PR TITLE
Feat: Provided applyIcon public method in icon component for dynamic icon loading

### DIFF
--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -73,11 +73,15 @@ export class FaIconComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes) {
-      this.updateIconSpec();
-      this.updateParams();
-      this.updateIcon();
-      this.renderIcon();
+      this.applyIcon();
     }
+  }
+
+  public applyIcon() {
+    this.updateIconSpec();
+    this.updateParams();
+    this.updateIcon();
+    this.renderIcon();
   }
 
   /**


### PR DESCRIPTION
This PR resolves #72.
When creating the Icon component dynamically from Angular's ComponentFactoryResolver, it isn't applied automatically.

Therefore to apply the icon, we needed to call ngOnChanges:
`
componentRef.instance.ngOnChanges({});
`

Thus this PR provides an applyIcon() method to update the icon manually:
`
componentRef.instance.applyIcon();
`