### PR TITLE
Correct prefix for regular style library

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ library.add(faCalendar);
 ```
 
 ```html
-<fa-icon [icon]="['fas', 'calendar']"></fa-icon>
+<fa-icon [icon]="['far', 'calendar']"></fa-icon>
 ```
 
 Adding an icon from the Pro-only Light style:


### PR DESCRIPTION
I was having trouble getting a regular icon to show up instead of the solid version. I saw this in the documentation and think it's wrong. The prefix here should be "far" for regular, right?