### PR TITLE
Fa stack

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,6 +35,7 @@ Take your icons to the next level with these advanced features.
 * [Transform](./usage/features.md#transform)
 * [Stateful Animations](./usage/features.md#stateful-animations)
 * [Transform within binding](./usage/features.md#transform-within-binding)
+* [Stacked icons](./usage/features.md#stacked-icons)
 * [Layers](./usage/features.md#layers)
 * [Layers with text](./usage/features.md#layers-with-text)
 * [Layers with counter](./usage/features.md#layers-with-counter)

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -99,6 +99,17 @@ The following features are available as part of Font Awesome. Note that the synt
 ```
 (Slide input range to "turn up the magic")
 
+### Stacked icons
+
+[FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/stacking-icons):
+
+```html
+<fa-stack>
+  <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
+  <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x"></fa-icon>
+</fa-stack>
+```
+
 ### Layers
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/layering):
 

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -23,6 +23,13 @@
 <fa-icon [icon]="faMagic" transform="rotate-{{magicLevel}}"></fa-icon>
 <input type='range' [value]="magicLevel" (input)="magicLevel = $event.target.value"/>
 
+<h3>Stack</h3>
+<p>Stack multiple icons into one.</p>
+<fa-stack>
+  <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
+  <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x"></fa-icon>
+</fa-stack>
+
 <h3>Layers</h3>
 <p>Custom icons created with multiple layers.</p>
 <div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,21 +1,22 @@
 import { Component } from '@angular/core';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faFlag, faUser as regularUser } from '@fortawesome/free-regular-svg-icons';
 import {
-  faUser,
-  faSync,
-  faBell,
-  faTimes,
-  faMagic,
   faAdjust,
-  faCoffee,
+  faBatteryQuarter,
+  faBell,
   faCircle,
-  faSquare,
-  faMobile,
+  faCoffee,
   faEllipsisH,
   faFighterJet,
-  faBatteryQuarter
+  faFlag as solidFlag,
+  faMagic,
+  faMobile,
+  faSquare,
+  faSync,
+  faTimes,
+  faUser
 } from '@fortawesome/free-solid-svg-icons';
-import { faUser as regularUser, faFlag } from '@fortawesome/free-regular-svg-icons';
-import { library } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
   selector: 'app-root',
@@ -26,6 +27,7 @@ export class AppComponent {
   faBell = faBell;
   faSync = faSync;
   faFlag = faFlag;
+  solidFlag = solidFlag;
   faTimes = faTimes;
   faMagic = faMagic;
   faAdjust = faAdjust;

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -5,6 +5,7 @@ import { FaIconComponent } from './icon/icon.component';
 import { FaLayersComponent } from './layers/layers.component';
 import { FaLayersTextComponent } from './layers/layers-text.component';
 import { FaLayersCounterComponent } from './layers/layers-counter.component';
+import { FaStackItemSizeDirective } from './stack/stack-item-size.directive';
 import { FaStackComponent } from './stack/stack.component';
 
 @NgModule({
@@ -15,6 +16,7 @@ import { FaStackComponent } from './stack/stack.component';
     FaLayersTextComponent,
     FaLayersCounterComponent,
     FaStackComponent,
+    FaStackItemSizeDirective,
   ],
   exports: [
     FaIconComponent,
@@ -22,6 +24,7 @@ import { FaStackComponent } from './stack/stack.component';
     FaLayersTextComponent,
     FaLayersCounterComponent,
     FaStackComponent,
+    FaStackItemSizeDirective,
   ],
 })
 export class FontAwesomeModule {

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -5,6 +5,7 @@ import { FaIconComponent } from './icon/icon.component';
 import { FaLayersComponent } from './layers/layers.component';
 import { FaLayersTextComponent } from './layers/layers-text.component';
 import { FaLayersCounterComponent } from './layers/layers-counter.component';
+import { FaStackComponent } from './stack/stack.component';
 
 @NgModule({
   imports: [CommonModule],
@@ -13,12 +14,14 @@ import { FaLayersCounterComponent } from './layers/layers-counter.component';
     FaLayersComponent,
     FaLayersTextComponent,
     FaLayersCounterComponent,
+    FaStackComponent,
   ],
   exports: [
     FaIconComponent,
     FaLayersComponent,
     FaLayersTextComponent,
     FaLayersCounterComponent,
+    FaStackComponent,
   ],
 })
 export class FontAwesomeModule {

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Host, HostBinding, Input, OnChanges, Optional, Renderer2, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, Input, OnChanges, Optional, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FaSymbol,
@@ -21,7 +21,7 @@ import { FaProps } from '../shared/models/props.model';
 import { faClassList } from '../shared/utils/classlist.util';
 
 import { faNormalizeIconSpec } from '../shared/utils/normalize-icon-spec.util';
-import { FaStackComponent } from '../stack/stack.component';
+import { FaStackItemSizeDirective } from '../stack/stack-item-size.directive';
 import { FaIconService } from './icon.service';
 
 @Component({
@@ -70,17 +70,12 @@ export class FaIconComponent implements OnChanges {
   constructor(
     private sanitizer: DomSanitizer,
     private iconService: FaIconService,
-    private renderer: Renderer2,
-    private elementRef: ElementRef,
-    @Host() @Optional() private stackParent: FaStackComponent
+    @Optional() private stackItem: FaStackItemSizeDirective,
   ) {
   }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes) {
-      if (this.stackParent != null && this.size != null) {
-        this.renderer.addClass(this.elementRef.nativeElement, `fa-stack-${this.size}`);
-      }
       const normalizedIcon = this.normalizeIcon();
       const params = this.buildParams();
       this.renderIcon(normalizedIcon, params);
@@ -103,6 +98,7 @@ export class FaIconComponent implements OnChanges {
       pull: this.pull || null,
       rotate: this.rotate || null,
       fixedWidth: this.fixedWidth,
+      stackItemSize: this.stackItem != null ? this.stackItem.stackItemSize : null,
     };
 
     const parsedTransform = typeof this.transform === 'string' ? parse.transform(this.transform) : this.transform;
@@ -110,7 +106,7 @@ export class FaIconComponent implements OnChanges {
     return {
       title: this.title,
       transform: parsedTransform,
-      classes: [...faClassList(classOpts, this.stackParent != null), ...this.classes],
+      classes: [...faClassList(classOpts), ...this.classes],
       mask: faNormalizeIconSpec(this.mask, this.iconService.defaultPrefix),
       styles: this.styles,
       symbol: this.symbol

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -22,6 +22,7 @@ import { faClassList } from '../shared/utils/classlist.util';
 
 import { faNormalizeIconSpec } from '../shared/utils/normalize-icon-spec.util';
 import { FaIconService } from './icon.service';
+import { FaStackComponent } from '../stack/stack.component';
 
 @Component({
   selector: 'fa-icon',
@@ -66,7 +67,11 @@ export class FaIconComponent implements OnChanges {
   @HostBinding('innerHTML')
   public renderedIconHTML: SafeHtml;
 
-  constructor(private sanitizer: DomSanitizer, private iconService: FaIconService) {}
+  constructor(
+      private sanitizer: DomSanitizer,
+      private iconService: FaIconService,
+      private stackParent: FaStackComponent
+      ) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes) {
@@ -91,7 +96,7 @@ export class FaIconComponent implements OnChanges {
       size: this.size || null,
       pull: this.pull || null,
       rotate: this.rotate || null,
-      fixedWidth: this.fixedWidth
+      fixedWidth: this.fixedWidth,
     };
 
     const parsedTransform = typeof this.transform === 'string' ? parse.transform(this.transform) : this.transform;
@@ -99,7 +104,7 @@ export class FaIconComponent implements OnChanges {
     return {
       title: this.title,
       transform: parsedTransform,
-      classes: [...faClassList(classOpts), ...this.classes],
+      classes: [...faClassList(classOpts, !!this.stackParent), ...this.classes],
       mask: faNormalizeIconSpec(this.mask, this.iconService.defaultPrefix),
       styles: this.styles,
       symbol: this.symbol

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, Host, HostBinding, Input, OnChanges, Optional, Renderer2, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FaSymbol,
@@ -21,8 +21,8 @@ import { FaProps } from '../shared/models/props.model';
 import { faClassList } from '../shared/utils/classlist.util';
 
 import { faNormalizeIconSpec } from '../shared/utils/normalize-icon-spec.util';
-import { FaIconService } from './icon.service';
 import { FaStackComponent } from '../stack/stack.component';
+import { FaIconService } from './icon.service';
 
 @Component({
   selector: 'fa-icon',
@@ -68,13 +68,19 @@ export class FaIconComponent implements OnChanges {
   public renderedIconHTML: SafeHtml;
 
   constructor(
-      private sanitizer: DomSanitizer,
-      private iconService: FaIconService,
-      private stackParent: FaStackComponent
-      ) {}
+    private sanitizer: DomSanitizer,
+    private iconService: FaIconService,
+    private renderer: Renderer2,
+    private elementRef: ElementRef,
+    @Host() @Optional() private stackParent: FaStackComponent
+  ) {
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes) {
+      if (this.stackParent != null && this.size != null) {
+        this.renderer.addClass(this.elementRef.nativeElement, `fa-stack-${this.size}`);
+      }
       const normalizedIcon = this.normalizeIcon();
       const params = this.buildParams();
       this.renderIcon(normalizedIcon, params);
@@ -104,7 +110,7 @@ export class FaIconComponent implements OnChanges {
     return {
       title: this.title,
       transform: parsedTransform,
-      classes: [...faClassList(classOpts, !!this.stackParent), ...this.classes],
+      classes: [...faClassList(classOpts, this.stackParent != null), ...this.classes],
       mask: faNormalizeIconSpec(this.mask, this.iconService.defaultPrefix),
       styles: this.styles,
       symbol: this.symbol

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -21,7 +21,7 @@ function queryByCss(fixture: ComponentFixture<any>, className: string): ElementR
   return fixture.debugElement.query(By.css(className));
 }
 
-describe('FaLayersCompoennt', () => {
+describe('FaLayersComponent', () => {
   it('should render layers icon', () => {
     @Component({
       selector: 'fa-host',
@@ -62,33 +62,7 @@ describe('FaLayersCompoennt', () => {
     expect(queryByCss(fixture, '.fa-2x')).toBeTruthy();
   });
 
-  it('should include fixed width if no value given', () => {
-    @Component({
-      selector: 'fa-host',
-      template: '<fa-layers fixedWidth></fa-layers>'
-    })
-    class HostComponent {
-    }
-
-    const fixture = initTest(HostComponent);
-    fixture.detectChanges();
-    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
-  });
-
-  it('should include fixed width if value given', () => {
-    @Component({
-      selector: 'fa-host',
-      template: '<fa-layers fixedWidth="fixedWidth"></fa-layers>'
-    })
-    class HostComponent {
-    }
-
-    const fixture = initTest(HostComponent);
-    fixture.detectChanges();
-    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
-  });
-
-  it('should include fixed width if value bound', () => {
+  it('should include fixed width', () => {
     @Component({
       selector: 'fa-host',
       template: '<fa-layers [fixedWidth]="true"></fa-layers>'

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -10,10 +10,10 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 })
 export class FaLayersComponent implements OnInit, OnChanges {
   @Input() size?: SizeProp;
-  @Input() fixedWidth?: boolean;
 
-  @HostBinding('class.fa-fw') get isFixedWidth() { return this.fixedWidth || <any>this.fixedWidth === ''; }
-
+  @Input()
+  @HostBinding('class.fa-fw')
+  fixedWidth?: boolean;
 
   constructor(
     private renderer: Renderer2,

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -10,10 +10,10 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 })
 export class FaLayersComponent implements OnInit, OnChanges {
   @Input() size?: SizeProp;
+  @Input() fixedWidth?: boolean;
 
-  @Input()
-  @HostBinding('class.fa-fw')
-  fixedWidth?: boolean;
+  @HostBinding('class.fa-fw') get isFixedWidth() { return this.fixedWidth || <any>this.fixedWidth === ''; }
+
 
   constructor(
     private renderer: Renderer2,

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -6,3 +6,4 @@ export { FaLayersComponent } from './layers/layers.component';
 export { FaLayersTextComponent } from './layers/layers-text.component';
 export { FaLayersCounterComponent } from './layers/layers-counter.component';
 export { FaStackComponent } from './stack/stack.component';
+export { FaStackItemSizeDirective } from './stack/stack-item-size.directive';

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -5,3 +5,4 @@ export { FaIconService } from './icon/icon.service';
 export { FaLayersComponent } from './layers/layers.component';
 export { FaLayersTextComponent } from './layers/layers-text.component';
 export { FaLayersCounterComponent } from './layers/layers-counter.component';
+export { FaStackComponent } from './stack/stack.component';

--- a/src/lib/shared/models/props.model.ts
+++ b/src/lib/shared/models/props.model.ts
@@ -29,4 +29,5 @@ export interface FaProps {
   transform?: string | Transform;
   symbol?: FaSymbol;
   style?: Styles;
+  stackItemSize?: '1x' | '2x';
 }

--- a/src/lib/shared/utils/classlist.util.ts
+++ b/src/lib/shared/utils/classlist.util.ts
@@ -4,7 +4,7 @@ import { FaProps } from '../models/props.model';
  * Fontawesome class list.
  * Returns classes array by props.
  */
-export const faClassList = (props: FaProps, hasStackParent: boolean = false): string[] => {
+export const faClassList = (props: FaProps): string[] => {
   const classes = {
     'fa-spin': props.spin,
     'fa-pulse': props.pulse,
@@ -15,12 +15,13 @@ export const faClassList = (props: FaProps, hasStackParent: boolean = false): st
     'fa-layers-counter': props.counter,
     'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
     'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both',
-    [`fa-${props.size}`]: props.size !== null && !hasStackParent,
+    [`fa-${props.size}`]: props.size !== null,
     [`fa-rotate-${props.rotate}`]: props.rotate !== null,
-    [`fa-pull-${props.pull}`]: props.pull !== null
+    [`fa-pull-${props.pull}`]: props.pull !== null,
+    [`fa-stack-${props.stackItemSize}`]: props.stackItemSize != null,
   };
 
   return Object.keys(classes)
-    .map(key => ((classes[key] || (<any>classes[key] === '')) ? key : null))
+    .map(key => (classes[key] ? key : null))
     .filter(key => key);
 };

--- a/src/lib/shared/utils/classlist.util.ts
+++ b/src/lib/shared/utils/classlist.util.ts
@@ -4,7 +4,7 @@ import { FaProps } from '../models/props.model';
  * Fontawesome class list.
  * Returns classes array by props.
  */
-export const faClassList = (props: FaProps): string[] => {
+export const faClassList = (props: FaProps, isChildOfStack: boolean = false): string[] => {
   const classes = {
     'fa-spin': props.spin,
     'fa-pulse': props.pulse,
@@ -15,7 +15,7 @@ export const faClassList = (props: FaProps): string[] => {
     'fa-layers-counter': props.counter,
     'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
     'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both',
-    [`fa-${props.size}`]: props.size !== null,
+    [`fa-${isChildOfStack ? 'stack-' : ''}${props.size}`]: props.size !== null,
     [`fa-rotate-${props.rotate}`]: props.rotate !== null,
     [`fa-pull-${props.pull}`]: props.pull !== null
   };

--- a/src/lib/shared/utils/classlist.util.ts
+++ b/src/lib/shared/utils/classlist.util.ts
@@ -4,7 +4,7 @@ import { FaProps } from '../models/props.model';
  * Fontawesome class list.
  * Returns classes array by props.
  */
-export const faClassList = (props: FaProps, isChildOfStack: boolean = false): string[] => {
+export const faClassList = (props: FaProps, hasStackParent: boolean = false): string[] => {
   const classes = {
     'fa-spin': props.spin,
     'fa-pulse': props.pulse,
@@ -15,12 +15,12 @@ export const faClassList = (props: FaProps, isChildOfStack: boolean = false): st
     'fa-layers-counter': props.counter,
     'fa-flip-horizontal': props.flip === 'horizontal' || props.flip === 'both',
     'fa-flip-vertical': props.flip === 'vertical' || props.flip === 'both',
-    [`fa-${isChildOfStack ? 'stack-' : ''}${props.size}`]: props.size !== null,
+    [`fa-${props.size}`]: props.size !== null && !hasStackParent,
     [`fa-rotate-${props.rotate}`]: props.rotate !== null,
     [`fa-pull-${props.pull}`]: props.pull !== null
   };
 
   return Object.keys(classes)
-    .map(key => (classes[key] ? key : null))
+    .map(key => ((classes[key] || (<any>classes[key] === '')) ? key : null))
     .filter(key => key);
 };

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -14,12 +14,12 @@ function initTest<T>(component: Type<T>): ComponentFixture<T> {
   return TestBed.createComponent(component);
 }
 
-function queryByCss(fixture: ComponentFixture<any>, cssSelector: string): ElementRef {
-  return fixture.nativeElement.querySelector(cssSelector);
+function queryByCss(fixture: ComponentFixture<any>, cssQuery: string): ElementRef {
+  return fixture.nativeElement.querySelector(cssQuery);
 }
 
-describe('FaStackComponent', () => {
-  it('should render stack icon', () => {
+describe('FaStackItemSizeDirective', () => {
+  it('should attach fa-stack-1x or fa-stack-2x classes to icons', () => {
     @Component({
       selector: 'fa-host',
       template: `
@@ -35,16 +35,17 @@ describe('FaStackComponent', () => {
 
     const fixture = initTest(HostComponent);
     fixture.detectChanges();
-    expect(fixture.nativeElement).toBeTruthy();
+    expect(queryByCss(fixture, '.fa-stack-1x')).toBeTruthy();
+    expect(queryByCss(fixture, '.fa-stack-2x')).toBeTruthy();
   });
 
-  it('should include size class', () => {
+  it('should throw an error when setting size input together with stackItemSize', () => {
     @Component({
       selector: 'fa-host',
       template: `
-          <fa-stack size="2x">
+          <fa-stack>
               <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-              <fa-icon [icon]="faUser" [inverse]="true" stackItemSize="1x"></fa-icon>
+              <fa-icon [icon]="faUser" [inverse]="true" size="1x" stackItemSize="1x"></fa-icon>
           </fa-stack>`
     })
     class HostComponent {
@@ -53,8 +54,9 @@ describe('FaStackComponent', () => {
     }
 
     const fixture = initTest(HostComponent);
-    fixture.detectChanges();
-    expect(queryByCss(fixture, '.fa-2x')).toBeTruthy();
+    expect(() => fixture.detectChanges()).toThrow(new Error(
+      'fa-icon is not allowed to customize size when used inside fa-stack. ' +
+      'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.'
+    ));
   });
 });
-

--- a/src/lib/stack/stack-item-size.directive.ts
+++ b/src/lib/stack/stack-item-size.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { SizeProp } from '@fortawesome/fontawesome-svg-core';
+import { FaStackComponent} from './stack.component';
+
+@Directive({
+  selector: 'fa-icon[stackItemSize]',
+})
+export class FaStackItemSizeDirective implements OnChanges {
+  /**
+   * Specify whether icon inside {@link FaStackComponent} should be rendered in
+   * regular size (1x) or as a larger icon (2x).
+   */
+  @Input() stackItemSize: '1x' | '2x' = '1x';
+
+  /**
+   * @internal
+   */
+  @Input() size?: SizeProp;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if ('size' in changes) {
+      throw new Error(
+        'fa-icon is not allowed to customize size when used inside fa-stack. ' +
+        'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.');
+    }
+  }
+}

--- a/src/lib/stack/stack.component.spec.ts
+++ b/src/lib/stack/stack.component.spec.ts
@@ -3,13 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { faUser, faMobile } from '@fortawesome/free-solid-svg-icons';
 import { By } from '@angular/platform-browser';
 import { FaIconComponent } from '../icon/icon.component';
-import { FaLayersComponent } from './layers.component';
-import { FaLayersTextComponent } from './layers-text.component';
+import { FaStackComponent } from './stack.component';
+import { library } from '@fortawesome/fontawesome-svg-core';
 
 function initTest<T>(component: Type<T>): ComponentFixture<T> {
   TestBed.configureTestingModule({
-    declarations: [ FaLayersComponent, FaIconComponent, FaLayersTextComponent, component ],
+    declarations: [ FaStackComponent, FaIconComponent, component ],
   });
+  library.add(faUser);
   return TestBed.createComponent(component);
 }
 
@@ -21,16 +22,20 @@ function queryByCss(fixture: ComponentFixture<any>, className: string): ElementR
   return fixture.debugElement.query(By.css(className));
 }
 
-describe('FaLayersCompoennt', () => {
-  it('should render layers icon', () => {
+function queryBySelector(fixture: ComponentFixture<any>, selector: string): ElementRef {
+  return fixture.debugElement.nativeElement.querySelector(selector);
+}
+
+
+describe('FaStackComponent', () => {
+  it('should render stack icon', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers>
+        <fa-stack>
           <fa-icon [icon]="faUser"></fa-icon>
           <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+        </fa-stack>`
     })
     class HostComponent {
       faUser = faUser;
@@ -46,11 +51,10 @@ describe('FaLayersCompoennt', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers size="2x">
+        <fa-stack size="2x">
           <fa-icon [icon]="faUser"></fa-icon>
           <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+        </fa-stack>`
     })
     class HostComponent {
       faUser = faUser;
@@ -65,7 +69,7 @@ describe('FaLayersCompoennt', () => {
   it('should include fixed width if no value given', () => {
     @Component({
       selector: 'fa-host',
-      template: '<fa-layers fixedWidth></fa-layers>'
+      template: '<fa-stack fixedWidth></fa-stack>'
     })
     class HostComponent {
     }
@@ -78,20 +82,7 @@ describe('FaLayersCompoennt', () => {
   it('should include fixed width if value given', () => {
     @Component({
       selector: 'fa-host',
-      template: '<fa-layers fixedWidth="fixedWidth"></fa-layers>'
-    })
-    class HostComponent {
-    }
-
-    const fixture = initTest(HostComponent);
-    fixture.detectChanges();
-    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
-  });
-
-  it('should include fixed width if value bound', () => {
-    @Component({
-      selector: 'fa-host',
-      template: '<fa-layers [fixedWidth]="true"></fa-layers>'
+      template: '<fa-stack fixedWidth="fixedWidth"></fa-stack>'
     })
     class HostComponent {
     }
@@ -104,49 +95,43 @@ describe('FaLayersCompoennt', () => {
   it('should not include fixed width', () => {
     @Component({
       selector: 'fa-host',
-      template: `
-        <fa-layers [fixedWidth]="false">
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+      template: '<fa-stack [fixedWidth]="false"></fa-stack>'
     })
     class HostComponent {
-      faUser = faUser;
-      faMobile = faMobile;
     }
     const fixture = initTest(HostComponent);
     fixture.detectChanges();
     expect(queryByCss(fixture, '.fa-fw')).toBeFalsy();
   });
 
-  it('should allow setting custom class on the host element', () => {
+  it('should add stack prefix to icon size class', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers class="custom-class" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [ngClass]="{'custom-class': true}" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" class="custom-class"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [class.custom-class]="true"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [ngClass]="{'custom-class': true}"></fa-layers>
-      `
+        <fa-stack size="2x">
+          <fa-icon [icon]="faUser" size="3x"></fa-icon>
+        </fa-stack>`
     })
     class HostComponent {
-      fixedWidth = true;
-      size = '4x';
     }
-
     const fixture = initTest(HostComponent);
-
     fixture.detectChanges();
-    const elements = fixture.debugElement.queryAll(By.css('fa-layers'));
-    for (const element of elements) {
-      expect(element.nativeElement.className).toContain('custom-class');
-      expect(element.nativeElement.className).toContain('fa-layers');
-      expect(element.nativeElement.className).toContain('fa-fw');
-      expect(element.nativeElement.className).toContain('fa-4x');
+    expect(queryByCss(fixture, 'fa-icon.fa-stack-3x')).toBeTruthy();
+  });
+
+  it('should not add size to svg element', () => {
+    @Component({
+      selector: 'fa-host',
+      template: `
+        <fa-stack size="2x">
+          <fa-icon icon="user" size="3x" inverse></fa-icon>
+        </fa-stack>`
+    })
+    class HostComponent {
     }
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryBySelector(fixture, 'svg.fa-3x')).toBeFalsy();
   });
 });
 

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,0 +1,38 @@
+import { Component, ElementRef, HostBinding, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
+import { SizeProp } from '@fortawesome/fontawesome-svg-core';
+
+/**
+ * Fontawesome layers.
+ */
+@Component({
+  selector: 'fa-stack',
+  template: `<ng-content select="fa-icon"></ng-content>`,
+})
+export class FaStackComponent implements OnInit, OnChanges {
+  @Input() size?: SizeProp;
+
+  @Input()
+  @HostBinding('class.fa-fw')
+  fixedWidth?: boolean;
+
+  constructor(
+    private renderer: Renderer2,
+    private elementRef: ElementRef,
+  ) {
+  }
+
+  ngOnInit() {
+    this.renderer.addClass(this.elementRef.nativeElement, 'fa-stack');
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if ('size' in changes) {
+      if (changes.size.currentValue != null) {
+        this.renderer.addClass(this.elementRef.nativeElement, `fa-${changes.size.currentValue}`);
+      }
+      if (changes.size.previousValue != null) {
+        this.renderer.removeClass(this.elementRef.nativeElement, `fa-${changes.size.previousValue}`);
+      }
+    }
+  }
+}

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,18 +1,19 @@
-import { Component, ElementRef, HostBinding, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
-/**
- * Fontawesome layers.
- */
 @Component({
   selector: 'fa-stack',
-  template: `<ng-content select="fa-icon"></ng-content>`,
+  // TODO: See if it is better to select fa-icon and throw if it does not have stackItemSize directive
+  template: `<ng-content select="fa-icon[stackItemSize]"></ng-content>`,
 })
 export class FaStackComponent implements OnInit, OnChanges {
+  /**
+   * Size of the stacked icon.
+   * Note that stacked icon is by default 2 times bigger, than non-stacked icon.
+   * You'll need to set size using custom CSS to align stacked icon with a
+   * simple one. E.g. `fa-stack { font-size: 0.5em; }`.
+   */
   @Input() size?: SizeProp;
-  @Input() fixedWidth?: boolean;
-
-  @HostBinding('class.fa-fw') get isFixedWidth() { return this.fixedWidth || <any>this.fixedWidth === ''; }
 
   constructor(
     private renderer: Renderer2,

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -10,10 +10,9 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 })
 export class FaStackComponent implements OnInit, OnChanges {
   @Input() size?: SizeProp;
+  @Input() fixedWidth?: boolean;
 
-  @Input()
-  @HostBinding('class.fa-fw')
-  fixedWidth?: boolean;
+  @HostBinding('class.fa-fw') get isFixedWidth() { return this.fixedWidth || <any>this.fixedWidth === ''; }
 
   constructor(
     private renderer: Renderer2,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "strictNullChecks": false,
+    "stripInternal": true,
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
The stacking isn't incluided in angular-fontawesome. I added an fa-stack. Also added some checks for empty string on props so that the input properties like 'inverse' can be used without any values:
`<fa-stack size='2x'><fa-icon icon='square' size='2x'></fa-icon><fa-icon icon='flag' size="1x" inverse></fa-icon></fa-stack>`