### PR TITLE
Added component for working with Duotone icons

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ Take advantage of the other FontAwesome icon styles.
 * [Brand](./usage/using-other-styles.md#brand-icons)
 * [Regular](./usage/using-other-styles.md#regular-icons)
 * [Light (Pro Only)](./usage/using-other-styles.md#pro-only-light-icons)
+* [Duotone (Pro Only)](./usage/using-other-styles.md#pro-only-duotone-icons)
 
 ## Features
 Utilize core FontAwesome features
@@ -27,6 +28,14 @@ Utilize core FontAwesome features
 * [Pull](./usage/features.md#pull)
 * [Custom Classes](./usage/features.md#custom-classes)
 * [Default Style](./usage/features.md#default-style)
+
+## Features specific for Duotone icons
+Additional features available for Duotone icons
+
+* [Basic use](./usage/features.md#basic-use)
+* [Swap layers opacity](./usage/features.md#swap-layers-opacity)
+* [Customize layers opacity](./usage/features.md#customize-layers-opacity)
+* [Customize layers color](./usage/features.md#customize-layers-color)
 
 ## Advanced Features
 Take your icons to the next level with these advanced features.

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -71,6 +71,42 @@ The following features are available as part of Font Awesome. Note that the synt
 <fa-icon [icon]="['fas', 'coffee']" [styles]="{'stroke': 'red', 'color': 'red'}"></fa-icon>
 ```
 
+## Duotone icons
+
+### Basic use
+
+[FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#basic-use):
+
+```html
+<fa-duotone-icon [icon]="['fad', 'coffee']"></fa-duotone-icon>
+```
+
+### Swap layers opacity
+
+[FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#swapping-layers):
+
+```html
+<fa-duotone-icon [icon]="['fad', 'coffee']" swapOpacity="true"></fa-duotone-icon>
+```
+
+### Customize layers opacity
+
+[FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity):
+
+```html
+<fa-duotone-icon [icon]="['fad', 'coffee']" primaryOpacity="0.9"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryOpacity="0.1"></fa-duotone-icon>
+```
+
+### Customize layers color
+
+[FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#coloring):
+
+```html
+<fa-duotone-icon [icon]="['fad', 'coffee']" primaryColor="red"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryColor="blue"></fa-duotone-icon>
+```
+
 ## Advanced Usage
 
 ### Mask

--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -80,9 +80,22 @@ library.add(faArrowAltRight);
 <fa-icon [icon]="['fal', 'calendar']"></fa-icon>
 ```
 
-## Duotone icons
+## Pro-only Duotone Icons
 
-Duotone icons are currently in pre-release and are coming soon to this component.
+```bash
+$ yarn add @fortawesome/pro-duotone-svg-icons
+```
+
+```javascript
+import { faCamera } from '@fortawesome/pro-duotone-svg-icons';
+
+// Add an icon to the library for convenient access in other components
+library.add(faCamera);
+```
+
+```html
+<fa-duotone-icon [icon]="['fad', 'camera']"></fa-duotone-icon>
+```
 
 ## Same Icon from Multiple Styles
 

--- a/package.json
+++ b/package.json
@@ -82,9 +82,8 @@
     "svg"
   ],
   "peerDependencies": {
-    "@angular/common": "^8.0.0-rc.5",
     "@angular/core": "^8.0.0-rc.5",
-    "@fortawesome/fontawesome-svg-core": "^1.2.0"
+    "@fortawesome/fontawesome-svg-core": "^1.2.21"
   },
   "ngPackage": {
     "lib": {

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -1,21 +1,37 @@
 <h1>Font Awesome examples</h1>
+
 <h3>Icon as Object (with title attribute—inspect the DOM to see it)</h3>
 <fa-icon [icon]="faCoffee" title="Coffee: Best Drink Ever"></fa-icon>
+
 <h3>Icon looked up in library by name</h3>
 <p>Possible after adding the <code>faUser</code> icon from the <code>free-solid-svg-icons</code> package to the library.</p>
 <p>The default prefix of <code>fas</code> is assumed. Also, add a border.</p>
 <fa-icon icon='user' [border]="true"></fa-icon>
+
+<h3>Duotone icons</h3>
+<fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>
+<p>Swap layer opacity.</p>
+<fa-duotone-icon [icon]="faDummy" swapOpacity="true"></fa-duotone-icon>
+<p>Custom primary or secondary layer opacity.</p>
+<fa-duotone-icon [icon]="faDummy" primaryOpacity="0.7" secondaryOpacity="0.1"></fa-duotone-icon>
+<p>Custom primary or secondary layer color.</p>
+<fa-duotone-icon [icon]="faDummy" primaryColor="red" secondaryColor="blue"></fa-duotone-icon>
+
 <h3>Icon with Non-default Style Prefix Using [prefix, iconName]</h3>
 <p><code>icon</code> should be set equal to an array object with two string elements: the prefix and the icon name.</p>
 <p>Using a string for an icon name also requires that this icon has been added to the library with <code>library.add()</code></p>
 <fa-icon [icon]="['far','user']"></fa-icon>
+
 <h3>Icon as Object with non-Default Prefix</h3>
 <p>The icon object knows its own prefix, so the prefix is not specified in this case.</p>
 <fa-icon [icon]="regularUser"></fa-icon>
+
 <h3>With Mask and Transform</h3>
 <fa-icon [icon]="faCircle" transform="shrink-9 right-4" [mask]="faSquare"></fa-icon>
+
 <h3>Change Size</h3>
 <fa-icon [icon]="faAdjust" size="2x"></fa-icon>
+
 <h3>Animation</h3>
 <p>Click to toggle animation.</p>
 <fa-icon [icon]="faSync" [spin]="isSyncAnimated" (click)="isSyncAnimated =! isSyncAnimated"></fa-icon>
@@ -70,10 +86,12 @@
 
 <app-alternate-prefix></app-alternate-prefix>
 
+
 <h3>When using text layer outside layers component</h3>
 <p>Expect to see an error on the JavaScript console, and nothing shown between these bars:
   |<fa-layers-counter [content]="notificationsCounter | number"></fa-layers-counter>|
 </p>
+
 
 <h3>Intentionally Missing Icon</h3>
 <p>Expect to see an error on the JavaScript console, and nothing shown between these bars: |<fa-icon [icon]="undefined"></fa-icon>|</p>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { library } from '@fortawesome/fontawesome-svg-core';
+import { IconDefinition, IconName, library } from '@fortawesome/fontawesome-svg-core';
 import { faFlag, faUser as regularUser } from '@fortawesome/free-regular-svg-icons';
 import {
   faAdjust,
@@ -39,6 +39,20 @@ export class AppComponent {
   faEllipsisH = faEllipsisH;
   faFighterJet = faFighterJet;
   faBatteryQuarter = faBatteryQuarter;
+  faDummy: IconDefinition = {
+    prefix: 'fad',
+    iconName: 'dummy' as IconName,
+    icon: [
+      512,
+      512,
+      [],
+      'f030',
+      [
+        'M50 50 H412 V250 H50 Z',
+        'M50 262 H412 V462 H50 Z'
+      ]
+    ]
+  };
 
   notificationsCounter = 1000;
   isSyncAnimated = true;

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -1,17 +1,16 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-
+import { FaDuotoneIconComponent } from './icon/duotone-icon.component';
 import { FaIconComponent } from './icon/icon.component';
-import { FaLayersComponent } from './layers/layers.component';
-import { FaLayersTextComponent } from './layers/layers-text.component';
 import { FaLayersCounterComponent } from './layers/layers-counter.component';
+import { FaLayersTextComponent } from './layers/layers-text.component';
+import { FaLayersComponent } from './layers/layers.component';
 import { FaStackItemSizeDirective } from './stack/stack-item-size.directive';
 import { FaStackComponent } from './stack/stack.component';
 
 @NgModule({
-  imports: [CommonModule],
   declarations: [
     FaIconComponent,
+    FaDuotoneIconComponent,
     FaLayersComponent,
     FaLayersTextComponent,
     FaLayersCounterComponent,
@@ -20,6 +19,7 @@ import { FaStackComponent } from './stack/stack.component';
   ],
   exports: [
     FaIconComponent,
+    FaDuotoneIconComponent,
     FaLayersComponent,
     FaLayersTextComponent,
     FaLayersCounterComponent,

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
+import { faDummy, initTest, queryByCss } from '../../testing/helpers';
+import { FaDuotoneIconComponent } from './duotone-icon.component';
+
+describe('FaDuotoneIconComponent', () => {
+  it('should render the duotone icon', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg')).toBeTruthy();
+  });
+
+  it('should allow to swap opacity of the layers', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy" [swapOpacity]="true"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg').classList.contains('fa-swap-opacity')).toBeTruthy();
+  });
+
+  it('should allow to customize opacity of the primary layer', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy" [primaryOpacity]="0.1"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg').style.getPropertyValue('--fa-primary-opacity')).toBe(' 0.1');
+  });
+
+  it('should allow to customize opacity of the secondary layer', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy" [secondaryOpacity]="0.9"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg').style.getPropertyValue('--fa-secondary-opacity')).toBe(' 0.9');
+  });
+
+  it('should allow to customize color of the primary layer', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy" primaryColor="red"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg').style.getPropertyValue('--fa-primary-color')).toBe(' red');
+  });
+
+  it('should allow to customize color of the secondary layer', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faDummy" secondaryColor="red"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'svg').style.getPropertyValue('--fa-secondary-color')).toBe(' red');
+  });
+
+  it('should throw if specified icon is not a Duotone icon', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-duotone-icon [icon]="faUser"></fa-duotone-icon>'
+    })
+    class HostComponent {
+      faUser = faUser;
+    }
+
+    const fixture = initTest(HostComponent);
+    expect(() => fixture.detectChanges()).toThrow(new Error(
+      'The specified icon does not appear to be a Duotone icon. ' +
+      'Check that you specified the correct style: <fa-duotone-icon [icon]="[\'fab\', \'user\']"></fa-duotone-icon> ' +
+      'or use: <fa-icon icon="user"></fa-icon> instead.'
+    ));
+  });
+});

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -1,0 +1,88 @@
+import { Component, Input } from '@angular/core';
+import { FaIconComponent } from './icon.component';
+import { IconLookup } from '@fortawesome/fontawesome-svg-core';
+
+@Component({
+  selector: 'fa-duotone-icon',
+  template: ``
+})
+export class FaDuotoneIconComponent extends FaIconComponent {
+  /**
+   * Swap the default opacity of each duotone icon’s layers. This will make an
+   * icon’s primary layer have the default opacity of 40% rather than its
+   * secondary layer.
+   *
+   * @default false
+   */
+  @Input() swapOpacity?: 'true' | 'false' | boolean;
+
+  /**
+   * Customize the opacity of the primary icon layer.
+   * Valid values are in range [0, 1.0].
+   *
+   * @default 1.0
+   */
+  @Input() primaryOpacity?: string | number;
+
+  /**
+   * Customize the opacity of the secondary icon layer.
+   * Valid values are in range [0, 1.0].
+   *
+   * @default 0.4
+   */
+  @Input() secondaryOpacity?: string | number;
+
+  /**
+   * Customize the color of the primary icon layer.
+   * Accepts any valid CSS color value.
+   *
+   * @default CSS inherited color
+   */
+  @Input() primaryColor?: string;
+
+  /**
+   * Customize the color of the secondary icon layer.
+   * Accepts any valid CSS color value.
+   *
+   * @default CSS inherited color
+   */
+  @Input() secondaryColor?: string;
+
+  protected normalizeIcon(): IconLookup {
+    const lookup = super.normalizeIcon();
+
+    if (lookup != null && lookup.prefix !== 'fad') {
+      throw new Error(
+        'The specified icon does not appear to be a Duotone icon. ' +
+        'Check that you specified the correct style: ' +
+        `<fa-duotone-icon [icon]="['fab', '${lookup.iconName}']"></fa-duotone-icon> ` +
+        `or use: <fa-icon icon="${lookup.iconName}"></fa-icon> instead.`
+      );
+    }
+
+    return lookup;
+  }
+
+  protected buildParams() {
+    const params = super.buildParams();
+
+    if (this.swapOpacity === true || this.swapOpacity === 'true') {
+      params.classes.push('fa-swap-opacity');
+    }
+    if (this.primaryOpacity != null) {
+      params.styles['--fa-primary-opacity'] = this.primaryOpacity.toString();
+    }
+    if (this.secondaryOpacity != null) {
+      params.styles['--fa-secondary-opacity'] = this.secondaryOpacity.toString();
+    }
+    if (this.primaryColor != null) {
+      params.styles['--fa-primary-color'] = this.primaryColor;
+    }
+    if (this.secondaryColor != null) {
+      params.styles['--fa-secondary-color'] = this.secondaryColor;
+    }
+
+    return params;
+  }
+}
+

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -108,7 +108,7 @@ export class FaIconComponent implements OnChanges {
       transform: parsedTransform,
       classes: [...faClassList(classOpts), ...this.classes],
       mask: faNormalizeIconSpec(this.mask, this.iconService.defaultPrefix),
-      styles: this.styles,
+      styles: this.styles != null ? this.styles : {},
       symbol: this.symbol
     };
   }

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -1,36 +1,20 @@
-import { Component, Type, ElementRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { faUser, faMobile } from '@fortawesome/free-solid-svg-icons';
+import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { FaIconComponent } from '../icon/icon.component';
+import { SizeProp } from '@fortawesome/fontawesome-svg-core';
+import { faMobile, faUser } from '@fortawesome/free-solid-svg-icons';
+import { faDummy, initTest, queryByCss } from '../../testing/helpers';
 import { FaLayersComponent } from './layers.component';
-import { FaLayersTextComponent } from './layers-text.component';
-
-function initTest<T>(component: Type<T>): ComponentFixture<T> {
-  TestBed.configureTestingModule({
-    declarations: [ FaLayersComponent, FaIconComponent, FaLayersTextComponent, component ],
-  });
-  return TestBed.createComponent(component);
-}
-
-function svgLayers(fixture: ComponentFixture<any>): SVGElement {
-  return fixture.debugElement.nativeElement.querySelector('svg');
-}
-
-function queryByCss(fixture: ComponentFixture<any>, className: string): ElementRef {
-  return fixture.debugElement.query(By.css(className));
-}
 
 describe('FaLayersComponent', () => {
   it('should render layers icon', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers>
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+          <fa-layers>
+              <fa-icon [icon]="faUser"></fa-icon>
+              <fa-icon [icon]="faMobile"></fa-icon>
+              <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
+          </fa-layers>`
     })
     class HostComponent {
       faUser = faUser;
@@ -39,18 +23,18 @@ describe('FaLayersComponent', () => {
 
     const fixture = initTest(HostComponent);
     fixture.detectChanges();
-    expect(svgLayers(fixture)).toBeTruthy();
+    expect(queryByCss(fixture, 'svg')).toBeTruthy();
   });
 
   it('should include size class', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers size="2x">
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+          <fa-layers size="2x">
+              <fa-icon [icon]="faUser"></fa-icon>
+              <fa-icon [icon]="faMobile"></fa-icon>
+              <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
+          </fa-layers>`
     })
     class HostComponent {
       faUser = faUser;
@@ -79,16 +63,17 @@ describe('FaLayersComponent', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers [fixedWidth]="false">
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faMobile"></fa-icon>
-          <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
-        </fa-layers>`
+          <fa-layers [fixedWidth]="false">
+              <fa-icon [icon]="faUser"></fa-icon>
+              <fa-icon [icon]="faMobile"></fa-icon>
+              <fa-layers-text [content]="'User with mobile'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
+          </fa-layers>`
     })
     class HostComponent {
       faUser = faUser;
       faMobile = faMobile;
     }
+
     const fixture = initTest(HostComponent);
     fixture.detectChanges();
     expect(queryByCss(fixture, '.fa-fw')).toBeFalsy();
@@ -98,17 +83,17 @@ describe('FaLayersComponent', () => {
     @Component({
       selector: 'fa-host',
       template: `
-        <fa-layers class="custom-class" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [ngClass]="{'custom-class': true}" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" class="custom-class"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [class.custom-class]="true"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [ngClass]="{'custom-class': true}"></fa-layers>
+          <fa-layers class="custom-class" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
+          <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
+          <fa-layers [ngClass]="{'custom-class': true}" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
+          <fa-layers [fixedWidth]="fixedWidth" [size]="size" class="custom-class"></fa-layers>
+          <fa-layers [fixedWidth]="fixedWidth" [size]="size" [class.custom-class]="true"></fa-layers>
+          <fa-layers [fixedWidth]="fixedWidth" [size]="size" [ngClass]="{'custom-class': true}"></fa-layers>
       `
     })
     class HostComponent {
       fixedWidth = true;
-      size = '4x';
+      size: SizeProp = '4x';
     }
 
     const fixture = initTest(HostComponent);
@@ -121,6 +106,24 @@ describe('FaLayersComponent', () => {
       expect(element.nativeElement.className).toContain('fa-fw');
       expect(element.nativeElement.className).toContain('fa-4x');
     }
+  });
+
+  it('should support duotone icons', () => {
+    @Component({
+      selector: 'fa-host',
+      template: `
+          <fa-layers>
+              <fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>
+              <fa-layers-text [content]="'Dummy'" [styles]="{ color: 'Tomato' }"></fa-layers-text>
+          </fa-layers>`
+    })
+    class HostComponent {
+      faDummy = faDummy;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'fa-duotone-icon')).toBeTruthy();
   });
 });
 

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -6,7 +6,7 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
  */
 @Component({
   selector: 'fa-layers',
-  template: `<ng-content select="fa-icon, fa-layers-text, fa-layers-counter"></ng-content>`,
+  template: `<ng-content select="fa-icon, fa-duotone-icon, fa-layers-text, fa-layers-counter"></ng-content>`,
 })
 export class FaLayersComponent implements OnInit, OnChanges {
   @Input() size?: SizeProp;

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -1,6 +1,7 @@
 export { FontAwesomeModule } from './fontawesome.module';
 export { FaProps } from './shared/models/props.model';
 export { FaIconComponent } from './icon/icon.component';
+export { FaDuotoneIconComponent } from './icon/duotone-icon.component';
 export { FaIconService } from './icon/icon.service';
 export { FaLayersComponent } from './layers/layers.component';
 export { FaLayersTextComponent } from './layers/layers-text.component';

--- a/src/lib/stack/stack-item-size.directive.ts
+++ b/src/lib/stack/stack-item-size.directive.ts
@@ -3,7 +3,7 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaStackComponent} from './stack.component';
 
 @Directive({
-  selector: 'fa-icon[stackItemSize]',
+  selector: 'fa-icon[stackItemSize],fa-duotone-icon[stackItemSize]',
 })
 export class FaStackItemSizeDirective implements OnChanges {
   /**

--- a/src/lib/stack/stack.component.spec.ts
+++ b/src/lib/stack/stack.component.spec.ts
@@ -1,22 +1,7 @@
-import { Component, ElementRef, Type } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { library } from '@fortawesome/fontawesome-svg-core';
+import { Component } from '@angular/core';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
-import { FaIconComponent } from '../icon/icon.component';
-import { FaStackItemSizeDirective } from './stack-item-size.directive';
+import { faDummy, initTest, queryByCss } from '../../testing/helpers';
 import { FaStackComponent } from './stack.component';
-
-function initTest<T>(component: Type<T>): ComponentFixture<T> {
-  TestBed.configureTestingModule({
-    declarations: [FaStackComponent, FaStackItemSizeDirective, FaIconComponent, component],
-  });
-  library.add(faUser);
-  return TestBed.createComponent(component);
-}
-
-function queryByCss(fixture: ComponentFixture<any>, cssSelector: string): ElementRef {
-  return fixture.nativeElement.querySelector(cssSelector);
-}
 
 describe('FaStackComponent', () => {
   it('should render stack icon', () => {
@@ -36,6 +21,25 @@ describe('FaStackComponent', () => {
     const fixture = initTest(HostComponent);
     fixture.detectChanges();
     expect(fixture.nativeElement).toBeTruthy();
+  });
+
+  it('should work with duotone icons', () => {
+    @Component({
+      selector: 'fa-host',
+      template: `
+          <fa-stack>
+              <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
+              <fa-duotone-icon [icon]="dummyDuotoneIcon" [inverse]="true" stackItemSize="1x"></fa-duotone-icon>
+          </fa-stack>`
+    })
+    class HostComponent {
+      dummyDuotoneIcon = faDummy;
+      faCircle = faCircle;
+    }
+
+    const fixture = initTest(HostComponent);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, 'fa-duotone-icon')).toBeTruthy();
   });
 
   it('should include size class', () => {

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -4,7 +4,7 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 @Component({
   selector: 'fa-stack',
   // TODO: See if it is better to select fa-icon and throw if it does not have stackItemSize directive
-  template: `<ng-content select="fa-icon[stackItemSize]"></ng-content>`,
+  template: `<ng-content select="fa-icon[stackItemSize],fa-duotone-icon[stackItemSize]"></ng-content>`,
 })
 export class FaStackComponent implements OnInit, OnChanges {
   /**

--- a/src/testing/helpers.ts
+++ b/src/testing/helpers.ts
@@ -1,0 +1,47 @@
+import { Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconDefinition, IconName, library } from '@fortawesome/fontawesome-svg-core';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
+import { FaDuotoneIconComponent } from '../lib/icon/duotone-icon.component';
+import { FaIconComponent } from '../lib/icon/icon.component';
+import { FaLayersCounterComponent } from '../lib/layers/layers-counter.component';
+import { FaLayersTextComponent } from '../lib/layers/layers-text.component';
+import { FaLayersComponent } from '../lib/layers/layers.component';
+import { FaStackItemSizeDirective } from '../lib/stack/stack-item-size.directive';
+import { FaStackComponent } from '../lib/stack/stack.component';
+
+export function initTest<T>(component: Type<T>): ComponentFixture<T> {
+  TestBed.configureTestingModule({
+    declarations: [
+      FaIconComponent,
+      FaDuotoneIconComponent,
+      FaLayersComponent,
+      FaLayersTextComponent,
+      FaLayersCounterComponent,
+      FaStackComponent,
+      FaStackItemSizeDirective,
+      component,
+    ],
+  });
+  library.add(faUser);
+  return TestBed.createComponent(component);
+}
+
+export function queryByCss(fixture: ComponentFixture<any>, cssSelector: string): HTMLElement {
+  return fixture.nativeElement.querySelector(cssSelector);
+}
+
+export const faDummy: IconDefinition = {
+  prefix: 'fad',
+  iconName: 'dummy' as IconName,
+  icon: [
+    512,
+    512,
+    [],
+    'f030',
+    [
+      'M50 50 H412 V250 H50 Z',
+      'M50 262 H412 V462 H50 Z'
+    ]
+  ]
+};

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -20,6 +20,7 @@
     "enableResourceInlining": true
   },
   "exclude": [
+    "src/testing/*.ts",
     "src/test.ts",
     "**/*.spec.ts"
   ]


### PR DESCRIPTION
All features listed in the [official documentation](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons) are supported:

```html
Basic usage:
<fa-duotone-icon [icon]="['fad', 'coffee']"></fa-duotone-icon>

Swap layers opacity:
<fa-duotone-icon [icon]="['fad', 'coffee']" swapOpacity="true"></fa-duotone-icon>

Customize layers opacity:
<fa-duotone-icon [icon]="['fad', 'coffee']" primaryOpacity="0.9"></fa-duotone-icon>
<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryOpacity="0.1"></fa-duotone-icon>

Customize layers color:
<fa-duotone-icon [icon]="['fad', 'coffee']" primaryColor="red"></fa-duotone-icon>
<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryColor="blue"></fa-duotone-icon>
```

You can also render duotone icon using existing `<fa-icon [icon]="['fad', 'coffee']"></fa-icon>` component if you don't need any of these features. However attempt to render non-duotone icon using `<fa-duotone-icon [icon]="['fas', 'coffee']"></fa-duotone-icon>` will throw.

Fixes https://github.com/FortAwesome/angular-fontawesome/issues/156