### PR TITLE
Deprecated `listItem` input of the `FaIconComponent`

### DIFF
--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -44,6 +44,10 @@ export class FaIconComponent implements OnChanges {
   @Input() border?: boolean;
   @Input() inverse?: boolean;
   @Input() symbol?: FaSymbol;
+
+  /**
+   * @deprecated Since 0.5.0. Will be removed in 0.6.0. Use `fixedWidth` with your custom styles instead.
+   */
   @Input() listItem?: boolean;
   @Input() rotate?: RotateProp;
   @Input() fixedWidth?: boolean;


### PR DESCRIPTION
The input was not working and we don't want to support this pattern in
angular-fontawesome.

You can use `fixedWidth=true` and custom CSS to achieve similar
behavior:

```css
ul {
  list-style-type: none;
  padding-left: 20px;
}
```

Demo: https://stackblitz.com/edit/angular-z8v4ux-o2yduf

Fixes #51