### PR TITLE
Update file to reference library.add instead of library.addIcons

### DIFF
--- a/docs/usage/icon-library.md
+++ b/docs/usage/icon-library.md
@@ -36,7 +36,7 @@ import { AppComponent } from './app.component';
 export class AppModule {
   constructor(library: FaIconLibrary) {
     // Add an icon to the library for convenient access in other components
-    library.addIcons(faCoffee);
+    library.add(faCoffee);
   }
 }
 ```


### PR DESCRIPTION
library.add is used in the individual references on https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/using-other-styles.md#brand-icons, while here it says to use library.addIcons. However, this gives a type error when trying to add icons from the brand pack, like library.addIcons(faTwitter). Is there a difference between the two and which one should we use?
![image](https://user-images.githubusercontent.com/4422380/65458331-fe601c80-de12-11e9-8581-98004fdc929e.png)
