### PR TITLE
Removed pro-brands-svg-icons from using-other-styles.md

### DIFF
--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -31,7 +31,6 @@ library.add(faClock);
 
 ```
 $ yarn add @fortawesome/free-brands-svg-icons
-$ yarn add @fortawesome/pro-brands-svg-icons
 ```
 
 ```javascript


### PR DESCRIPTION
Updated the Brand Icon section by removing _pro-brands-svg-icons_ since there are no pro brand icons.