### PR TITLE
Fix dummy icon definition

### DIFF
--- a/testing/src/icon/mock-icon-library.service.ts
+++ b/testing/src/icon/mock-icon-library.service.ts
@@ -10,9 +10,7 @@ export const dummyIcon: IconDefinition = {
     512,
     [],
     'f030',
-    [
-      'M50 50 H462 V462 H50 Z'
-    ]
+    'M50 50 H462 V462 H50 Z'
   ]
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8297,9 +8297,9 @@ webdriver-js-extender@2.1.0:
     selenium-webdriver "^3.0.1"
 
 webdriver-manager@^12.0.6:
-  version "12.1.6"
-  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.1.6.tgz#9e5410c506d1a7e0a7aa6af91ba3d5bb37f362b6"
-  integrity sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==
+  version "12.1.7"
+  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.1.7.tgz#ed4eaee8f906b33c146e869b55e850553a1b1162"
+  integrity sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==
   dependencies:
     adm-zip "^0.4.9"
     chalk "^1.1.1"


### PR DESCRIPTION
Because path was in the array, icon was erroneously assumed to be a
duotone icon and error was reported when component was trying to render
a second path (i.e. missing second element of the array).