### PR TITLE
feat(fixed-width): support for global configuration

### DIFF
--- a/docs/usage/icon-library.md
+++ b/docs/usage/icon-library.md
@@ -67,3 +67,17 @@ export class AppComponent {
   }
 }
 ```
+
+## Apply fixed width by default
+
+The fixed width class, `fa-fw`, can be applied globally by injecting the `FaConfig` and modyfing the `fixedWidth` property.
+
+```ts
+import { FaConfig } from '@fortawesome/angular-fontawesome';
+
+export class AppComponent {
+  constructor(faConfig: FaConfig) {
+    faConfig.fixedWidth = true;
+  }
+}
+```

--- a/src/lib/config.spec.ts
+++ b/src/lib/config.spec.ts
@@ -5,5 +5,6 @@ describe('FaConfig', () => {
   it('should be created with a default value', inject([FaConfig], (service: FaConfig) => {
     expect(service).toBeTruthy();
     expect(service.defaultPrefix).toEqual('fas');
+    expect(service.fixedWidth).toBeFalsy();
   }));
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,6 +21,13 @@ export class FaConfig {
   fallbackIcon: IconDefinition = null;
 
   /**
+   * Set icons to the same fixed width.
+   * @see {@link: https://fontawesome.com/how-to-use/on-the-web/styling/fixed-width-icons}
+   * @default false
+   */
+  fixedWidth?: boolean;
+
+  /**
    * Whether components should lookup icon definitions in the global icon
    * library (the one available from
    * `import { library } from '@fortawesome/fontawesome-svg-core')`.

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -207,6 +207,77 @@ describe('FaIconComponent', () => {
     expect(queryByCss(fixture, 'svg').getAttribute('data-prefix')).toEqual('far');
   });
 
+  it('should have no fixed width by default', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-icon icon="user"></fa-icon>',
+    })
+    class HostComponent {
+      constructor(iconLibrary: FaIconLibrary) {
+        iconLibrary.addIcons(faUser, faUserRegular);
+      }
+    }
+
+    const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    fixture.detectChanges();
+    expect(queryByCss(fixture, '.fa-fw')).toBeFalsy();
+  });
+
+  it('should be able to set fixed width with default config', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-icon icon="user"></fa-icon>',
+    })
+    class HostComponent {
+      constructor(iconLibrary: FaIconLibrary) {
+        iconLibrary.addIcons(faUser, faUserRegular);
+      }
+    }
+
+    const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = true;
+    fixture.detectChanges();
+    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
+  });
+
+  it('should be able to set fixed width explicitly', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-icon icon="user" [fixedWidth]="true"></fa-icon>',
+    })
+    class HostComponent {
+      constructor(iconLibrary: FaIconLibrary) {
+        iconLibrary.addIcons(faUser, faUserRegular);
+      }
+    }
+
+    const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = false;
+    fixture.detectChanges();
+    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
+  });
+
+  it('should be able to override global fixed width explicitly', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-icon icon="user" [fixedWidth]="false"></fa-icon>',
+    })
+    class HostComponent {
+      constructor(iconLibrary: FaIconLibrary) {
+        iconLibrary.addIcons(faUser, faUserRegular);
+      }
+    }
+
+    const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = true;
+    fixture.detectChanges();
+    expect(queryByCss(fixture, '.fa-fw')).toBeFalsy();
+  });
+
   it('should use icon definition from the icon library', () => {
     @Component({
       selector: 'fa-host',

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -144,7 +144,7 @@ export class FaIconComponent implements OnChanges {
       size: this.size || null,
       pull: this.pull || null,
       rotate: this.rotate || null,
-      fixedWidth: this.fixedWidth,
+      fixedWidth: typeof this.fixedWidth === 'boolean' ? this.fixedWidth : this.config.fixedWidth,
       stackItemSize: this.stackItem != null ? this.stackItem.stackItemSize : null,
     };
 

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { faMobile, faUser } from '@fortawesome/free-solid-svg-icons';
 import { faDummy, initTest, queryByCss } from '../../testing/helpers';
-import { FaLayersComponent } from './layers.component';
+import { FaConfig } from '../config';
 
 describe('FaLayersComponent', () => {
   it('should render layers icon', () => {
@@ -48,7 +49,7 @@ describe('FaLayersComponent', () => {
     expect(queryByCss(fixture, '.fa-2x')).toBeTruthy();
   });
 
-  it('should include fixed width', () => {
+  it('should include fixed width when set explicitly', () => {
     @Component({
       selector: 'fa-host',
       template: '<fa-layers [fixedWidth]="true"></fa-layers>',
@@ -56,11 +57,27 @@ describe('FaLayersComponent', () => {
     class HostComponent {}
 
     const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = false;
     fixture.detectChanges();
     expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
   });
 
-  it('should not include fixed width', () => {
+  it('should include fixed width when set with global config', () => {
+    @Component({
+      selector: 'fa-host',
+      template: '<fa-layers></fa-layers>',
+    })
+    class HostComponent {}
+
+    const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = true;
+    fixture.detectChanges();
+    expect(queryByCss(fixture, '.fa-fw')).toBeTruthy();
+  });
+
+  it('should not include fixed width when set explicitly', () => {
     @Component({
       selector: 'fa-host',
       template: `
@@ -77,8 +94,10 @@ describe('FaLayersComponent', () => {
     }
 
     const fixture = initTest(HostComponent);
+    const config = TestBed.inject(FaConfig);
+    config.fixedWidth = true;
     fixture.detectChanges();
-    expect(queryByCss(fixture, '.fa-fw')).toBeFalsy();
+    expect(queryByCss(fixture, 'fa-layers.fa-fw')).toBeFalsy();
   });
 
   it('should allow setting custom class on the host element', () => {

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, HostBinding, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
-
+import { FaConfig } from '../config';
 /**
  * Fontawesome layers.
  */
@@ -15,10 +15,11 @@ export class FaLayersComponent implements OnInit, OnChanges {
 
   @Input() @HostBinding('class.fa-fw') fixedWidth?: boolean;
 
-  constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
+  constructor(private renderer: Renderer2, private elementRef: ElementRef, private config: FaConfig) {}
 
   ngOnInit() {
     this.renderer.addClass(this.elementRef.nativeElement, 'fa-layers');
+    this.fixedWidth = typeof this.fixedWidth === 'boolean' ? this.fixedWidth : this.config.fixedWidth;
   }
 
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
This adds support for `fixedWidth` property being applied globally to
the `icon` and `layers` components.

Closes #216

Thanks!