### PR TITLE
Fix ng add crash on Typescript 3.7.5

### DIFF
--- a/projects/schematics/src/ng-add/index.ts
+++ b/projects/schematics/src/ng-add/index.ts
@@ -1,12 +1,15 @@
 import { WorkspaceProject } from '@angular-devkit/core/src/experimental/workspace';
 import { chain, Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask, TslintFixTask } from '@angular-devkit/schematics/tasks';
+import {
+  createSourceFile,
+  ScriptTarget,
+} from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { addImportToModule } from '@schematics/angular/utility/ast-utils';
 import { InsertChange } from '@schematics/angular/utility/change';
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { addPackageJsonDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
-import { createSourceFile, ScriptTarget } from 'typescript';
 import { Schema } from './schema';
 import { angularFontawesomeVersion, iconPackVersion, svgCoreVersion } from './versions';
 


### PR DESCRIPTION
`angular-fontawesome` abuses `@schematics/angular` instead of re-implementing some AST manipulations. The problem is that source file is parsed by the workspace's TypeScript version (3.7.5 in this case), but `@schematics/angular` bundles TypeScript 3.8.3 and assumes that AST was produced by 3.8.3. The AST is incompatible, hence the crash.

The solution is to use TypeScript bundled with `@schematics/angular` to parse the source file instead of using workspace's version.

Fixes #237
Fixed #234