### PR TITLE
Make check for Duotone icon more robust

### DIFF
--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -101,7 +101,7 @@ describe('FaDuotoneIconComponent', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fab', 'user']\"></fa-duotone-icon> " +
+          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
           'or use: <fa-icon icon="user"></fa-icon> instead.',
       ),
     );

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -49,18 +49,18 @@ export class FaDuotoneIconComponent extends FaIconComponent {
   @Input() secondaryColor?: string;
 
   protected findIconDefinition(i: IconProp | IconDefinition): IconDefinition | null {
-    const lookup = super.findIconDefinition(i);
+    const definition = super.findIconDefinition(i);
 
-    if (lookup != null && lookup.prefix !== 'fad') {
+    if (definition != null && !Array.isArray(definition.icon[4])) {
       throw new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
           'Check that you specified the correct style: ' +
-          `<fa-duotone-icon [icon]="['fab', '${lookup.iconName}']"></fa-duotone-icon> ` +
-          `or use: <fa-icon icon="${lookup.iconName}"></fa-icon> instead.`,
+          `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
+          `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
       );
     }
 
-    return lookup;
+    return definition;
   }
 
   protected buildParams() {


### PR DESCRIPTION
Ultimately the Duotone icon is different from the regular icon in only way: instead of single path it has array of paths in the icon definition. Now check uses this fact to decide whether error should be thrown.

Also fixes typo in the error message (fab -> fad).