### PR TITLE
Distribute library using partial Ivy compilation mode

### DIFF
--- a/tsconfig.lib.prod.json
+++ b/tsconfig.lib.prod.json
@@ -4,6 +4,6 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
See https://blog.angular.io/upcoming-improvements-to-angular-library-distribution-76c02f782aa4 for more details.

BREAKING CHANGE:

Library can no longer be used by applications or libraries which still use View Engine compiler. For applications this should not be a problem as Angular 12 does not support View Engine for compiling applications. If you have a library which still uses View Engine and depends on angular-fontawesome, please stick with the 0.9.x release until your library has migrated.