### PR TITLE
Document support for new NPM Kits

### DIFF
--- a/docs/guide/advanced-uses.md
+++ b/docs/guide/advanced-uses.md
@@ -2,7 +2,7 @@
 
 While `<fa-icon>` component provides a convenient way to render a Font Awesome icon in the Angular app, there are situations where you can't use it. This guide describes such situations and how to use Font Awesome JavaScript API to deal with them.
 
-The Font Awesome JavaScript API is distributed as the [`@fortawesome/fontawesome-svg-core`](https://www.npmjs.com/package/@fortawesome/fontawesome-svg-core) package. The [documentation](https://fontawesome.com/v5.15/how-to-use/javascript-api/setup/getting-started) for the JavaScript API is available on the official website.
+The Font Awesome JavaScript API is distributed as the [`@fortawesome/fontawesome-svg-core`](https://www.npmjs.com/package/@fortawesome/fontawesome-svg-core) package. The [documentation](https://fontawesome.com/docs/apis/javascript/get-started) for the JavaScript API is available on the official website.
 
 ## Replace `<i>` tags with icons in the arbitrary HTML
 

--- a/docs/usage/explicit-reference.md
+++ b/docs/usage/explicit-reference.md
@@ -37,7 +37,7 @@ export class AppComponent {
 }
 ```
 
-You can also use a [https://fontawesome.com/kits](Font Awesome Kit). With a Kit
+You can also use a [Font Awesome Kit](https://fontawesome.com/kits). With a Kit
 you can upload your own icons or pick only the icons you'd like to use.
 
 [Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)

--- a/docs/usage/explicit-reference.md
+++ b/docs/usage/explicit-reference.md
@@ -36,3 +36,25 @@ export class AppComponent {
   faCoffee = faCoffee;
 }
 ```
+
+You can also use a [https://fontawesome.com/kits](Font Awesome Kit). With a Kit
+you can upload your own icons or pick only the icons you'd like to use.
+
+[Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)
+
+```typescript
+import { Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faCoffee } from '@awesome.me/kit-KIT_CODE/icons/classic/solid'; // KIT_CODE is a unique identifier for you Pro Kit
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [FontAwesomeModule],
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  faCoffee = faCoffee;
+}
+```
+

--- a/docs/usage/icon-library.md
+++ b/docs/usage/icon-library.md
@@ -55,6 +55,31 @@ export class AppComponent {
 }
 ```
 
+A better way can be to use a [https://fontawesome.com/kits](Font Awesome Kit) to only include the icons you choose. You can even upload your own icons.
+
+[Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)
+
+_In these examples, you would replace "KIT_CODE" with the unique identifier for your Pro Kit_
+
+```typescript
+import { Component } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { all } from '@awesome.me/kit-KIT_CODE/icons';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [FontAwesomeModule],
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  constructor(library: FaIconLibrary) {
+    // Add an icon to the library for convenient access in other components
+    library.addIcons(...all);
+  }
+}
+```
+
 ## Changing the default prefix
 
 The default prefix, `fas`, can be adjusted by injecting the `FaConfig` and modifying the `defaultPrefix` property.

--- a/docs/usage/icon-library.md
+++ b/docs/usage/icon-library.md
@@ -55,7 +55,7 @@ export class AppComponent {
 }
 ```
 
-A better way can be to use a [https://fontawesome.com/kits](Font Awesome Kit) to only include the icons you choose. You can even upload your own icons.
+A better way can be to use a [Font Awesome Kit](https://fontawesome.com/kits) to only include the icons you choose. You can even upload your own icons.
 
 [Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)
 

--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -45,35 +45,58 @@ $ yarn add @fortawesome/pro-regular-svg-icons
 import { faCalendar } from '@fortawesome/free-regular-svg-icons';
 ```
 
-## Pro-only Light Icons
+## Pro-only Icons
 
 ```bash
-$ yarn add @fortawesome/pro-light-svg-icons
+npm install --save @fortawesome/free-brands-svg-icons
+npm install --save @fortawesome/pro-solid-svg-icons
+npm install --save @fortawesome/pro-regular-svg-icons
+npm install --save @fortawesome/pro-light-svg-icons
+npm install --save @fortawesome/pro-thin-svg-icons
+npm install --save @fortawesome/pro-duotone-svg-icons
+npm install --save @fortawesome/sharp-solid-svg-icons
+npm install --save @fortawesome/sharp-regular-svg-icons
+npm install --save @fortawesome/sharp-light-svg-icons
+npm install --save @fortawesome/sharp-thin-svg-icons
 ```
+
+```bash
+yarn add @fortawesome/free-brands-svg-icons
+yarn add @fortawesome/pro-solid-svg-icons
+yarn add @fortawesome/pro-regular-svg-icons
+yarn add @fortawesome/pro-light-svg-icons
+yarn add @fortawesome/pro-thin-svg-icons
+yarn add @fortawesome/pro-duotone-svg-icons
+yarn add @fortawesome/sharp-solid-svg-icons
+yarn add @fortawesome/sharp-regular-svg-icons
+yarn add @fortawesome/sharp-light-svg-icons
+yarn add @fortawesome/sharp-thin-svg-icons
+```
+
+Example using the Light style:
 
 ```javascript
 import { faArrowAltRight } from '@fortawesome/pro-light-svg-icons';
 ```
 
-## Pro-only Duotone Icons
+## Pro-only Kit
+
+You can now use your [https://fontawesome.com/kits](Font Awesome Kit) with angular-fontawesome. With a Kit you can upload your own icons or pick only the icons you'd like to use.
+
+[Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)
+
+_In these examples, you would replace "KIT_CODE" with the unique identifier for your Pro Kit_
 
 ```bash
-$ yarn add @fortawesome/pro-duotone-svg-icons
+npm install --save @awesome.me/kit-KIT_CODE
+# or
+yarn add @awesome.me/kit-KIT_CODE
 ```
 
 ```javascript
-import { faCamera } from '@fortawesome/pro-duotone-svg-icons';
-````
-
-## Pro-only Sharp Solid Icons
-
-```bash
-$ yarn add @fortawesome/sharp-solid-svg-icons
+import { faArrowAltRight } from '@awesome.me/kit-KIT_CODE/icons/classic/solid';
+import { faMyIcon } from '@awesome.me/kit-KIT_CODE/icons/kit/custom';
 ```
-
-```javascript
-import { faCamera } from '@fortawesome/sharp-solid-svg-icons';
-````
 
 ## Same Icon from Multiple Styles
 

--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -81,7 +81,7 @@ import { faArrowAltRight } from '@fortawesome/pro-light-svg-icons';
 
 ## Pro-only Kit
 
-You can now use your [https://fontawesome.com/kits](Font Awesome Kit) with angular-fontawesome. With a Kit you can upload your own icons or pick only the icons you'd like to use.
+You can now use your [Font Awesome Kit](https://fontawesome.com/kits) with angular-fontawesome. With a Kit you can upload your own icons or pick only the icons you'd like to use.
 
 [Find out more about Kits and how you can use them in JavaScript projects](https://fontawesome.com/docs/web/setup/use-kit)
 


### PR DESCRIPTION
@devoto13 We've got a new feature on fontawesome.com we are calling "Kit Packages". You can basically install your Font Awesome Kit using npm.

It has a different API that the old SVG icon packages.

I was about to merge this in without checking with you but then changed my mind.

Let me know what you think about this when you have a moment.