### PR TITLE
Document how to correctly use fa-stack in standalone components

### DIFF
--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -154,6 +154,8 @@ Each `<fa-icon>` declared inside an `<fa-stack>` element **must** include the `s
 </fa-stack>
 ```
 
+When using standalone components, make sure to also add `FaStackItemSizeDirective` to the imports alongside with the `FaStackComponent`. Without the directive, the stacked icon will not render correctly.
+
 ### Layers
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/layering):
 


### PR DESCRIPTION
Angular is unable to detect missing directives (https://github.com/angular/angular/issues/20588) and it looks like there is no way to import the directive automatically whenever `FaStackComponent` is imported.

Closes #433