### PR TITLE
export IconDefinition in public_api.ts

### DIFF
--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -12,6 +12,7 @@ export { FaIconLibrary, FaIconLibraryInterface } from './icon-library';
 export { IconPrefix, IconName, IconLookup, IconDefinition, IconPack } from './types';
 
 export {
+  IconDefinition,
   IconParams,
   CounterParams,
   TextParams,


### PR DESCRIPTION
According to the doc `docs/guide/custom-icons.md`, this patch makes the example code work:
```typescript
import { IconDefinition } from '@fortawesome/angular-fontawesome';

...
```