### PR TITLE
Convert to use signal input and output

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,11 +5,11 @@ jobs:
     name: Font Awesome 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}
@@ -30,11 +30,11 @@ jobs:
     name: Font Awesome 6
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: ${{ hashFiles('yarn.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ---
 
-## [2.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/2.0.0) - 2025-03-18
+## [2.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/2.0.0) (work-in-progress)
 
 Converted all library internal component implementation to use reactive Signal APIs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 Converted all library internal component implementation to use reactive Signal API. Now it uses signal, compute, effect, viewChild, etc.
 
-### Breaking Change
-
-* Deprecated the `render` function from the `fa-icon` component. The way of loading component programatically has changed, [please refer here](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/features.md#programmatic-api) and migration guide [1.0.0 to 2.0.0](docs/upgrading/1.0.0-2.0.0.md)
+### Added
+* Documentation on changes in Programmatic API.
+* Documentation for upgrading 1.0.0 to 2.0.0
+* Updated code to use signal APIs.
 
 ### Removed
 
-* Angular 18.x is no longer supported. If you are using this version, please, stick with version 0.15.0.
+* Deprecated the `render` function from the `FaIconComponent`.
+* Programmatic API has changed, [please refer here](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/features.md#programmatic-api) and migration guide [1.0.0 to 2.0.0](docs/upgrading/1.0.0-2.0.0.md)
 
 ## [1.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/1.0.0) - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [2.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/2.0.0) - 2025-03-18
 
-Converted all internal component implementation to use reactive API signal, compute, effect, viewChild, etc.
+Converted all library internal component implementation to use reactive Signal API. Now it uses signal, compute, effect, viewChild, etc.
 
 ### Breaking Change
 
-* Deprecated the use of setting `FaIconComponent` component property directly, instead call `.set` over a property of component, [refer here](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/features.md#programmatic-api)
+* Deprecated the `render` function from the `fa-icon` component. The way of loading component programatically has changed, [please refer here](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/features.md#programmatic-api) and migration guide [1.0.0 to 2.0.0](docs/upgrading/1.0.0-2.0.0.md)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [2.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/2.0.0) - 2025-03-18
 
-Converted all library internal component implementation to use reactive Signal API. Now it uses signal, compute, effect, viewChild, etc.
+Converted all library internal component implementation to use reactive Signal APIs.
 
 ### Added
 * Documentation on changes in Programmatic API.
 * Documentation for upgrading 1.0.0 to 2.0.0
-* Updated code to use signal APIs.
+* Updated code to use signal APIs like signal, computed, effect, input, model.
+* Updated `changeDetection: ChangeDetectionStrategy.OnPush` 🚀 for all components.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ---
 
+## [2.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/2.0.0) - 2025-03-18
+
+Converted all internal component implementation to use reactive API signal, compute, effect, viewChild, etc.
+
+### Breaking Change
+
+* Deprecated the use of setting `FaIconComponent` component property directly, instead call `.set` over a property of component, [refer here](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/features.md#programmatic-api)
+
+### Removed
+
+* Angular 18.x is no longer supported. If you are using this version, please, stick with version 0.15.0.
+
 ## [1.0.0](https://github.com/FortAwesome/angular-fontawesome/releases/tag/1.0.0) - 2024-11-20
 
 There are no major changes in this release. The version bump is to signal that the library is stable now and no major breaking changes are expected in the future.

--- a/README.md
+++ b/README.md
@@ -136,5 +136,6 @@ being awesome contributors to this project. **We'd like to take a moment to reco
 [<img src="https://github.com/igorls.png?size=72" alt="igorls" width="72">](https://github.com/igorls)
 [<img src="https://github.com/jasonlundien.png?size=72" alt="jasonlundien" width="72">](https://github.com/jasonlundien)
 [<img src="https://github.com/FortAwesome.png?size=72" alt="Font Awesome Team" width="72">](https://github.com/orgs/FortAwesome/people)
+[<img src="https://github.com/pankajparkar.png?size=72" alt="pankajparkar" width="72">](https://github.com/pankajparkar)
 
 If we've missed someone (which is quite likely) submit a Pull Request to us and we'll get it resolved.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ npm install @fortawesome/angular-fontawesome@<version>
 | 0.14.x                           | 17.x       | 5.x && 6.x   | supported     |
 | 0.15.x                           | 18.x       | 5.x && 6.x   | supported     |
 | 1.x                              | 19.x       | 5.x && 6.x   | supported     |
+| 2.x                              | 19.x       | 5.x && 6.x   | supported     |
 
 ## Usage
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,3 +17,4 @@ You might also be interested in the larger umbrella project [upgrade guide](http
 * [0.9.0 to 0.10.0](docs/upgrading/0.9.0-0.10.0.md)
 * [0.11.0 to 0.12.0](docs/upgrading/0.11.0-0.12.0.md)
 * [0.14.0 to 0.15.0](docs/upgrading/0.14.0-0.15.0.md)
+* [1.0.0 to 2.0.0](docs/upgrading/1.0.0-2.0.0.md)

--- a/docs/upgrading/1.0.0-2.0.0.md
+++ b/docs/upgrading/1.0.0-2.0.0.md
@@ -1,0 +1,48 @@
+# Upgrading 1.0.0 to 2.0.0
+
+To create `FaIconComponent` dynamically:
+
+```diff
+@Component({
+  selector: 'fa-host',
+  template: `
+    <button (click)="createIcon()">
+      Create
+    </button>
+    <br>
+    <ng-container #host></ng-container>
+  `
+})
+class HostComponent {
+  readonly container = viewChild('host', { read: ViewContainerRef });
+
+  createIcon() {
+    if (!this.container()) { return; }
+
+    const componentRef = this.container().createComponent(FaIconComponent);
+-    componentRef.instance.icon = faUser;
+-    componentRef.instance.render();
+
++    componentRef.setInput('icon', faUser);
+  }
+}
+```
+
+To update `FaIconComponent` programmatically:
+
+```diff
+@Component({
+  selector: 'fa-host',
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+})
+class HostComponent {
+  readonly faUser = faUser;
+  readonly iconComponent = viewChild(FaIconComponent);
+
+  spinIcon() {
+    const iconComponent = this.iconComponent();
+-    iconComponent?.animation = 'spin';
++    iconComponent?.animation.set('spin');
+  }
+}
+```

--- a/docs/upgrading/1.0.0-2.0.0.md
+++ b/docs/upgrading/1.0.0-2.0.0.md
@@ -1,6 +1,8 @@
 # Upgrading 1.0.0 to 2.0.0
 
-To create `FaIconComponent` dynamically:
+Below approaches have changed
+
+## To create `FaIconComponent` dynamically: 
 
 ```diff
 @Component({
@@ -28,7 +30,7 @@ class HostComponent {
 }
 ```
 
-To update `FaIconComponent` programmatically:
+## To update `FaIconComponent` programmatically:
 
 ```diff
 @Component({

--- a/docs/upgrading/1.0.0-2.0.0.md
+++ b/docs/upgrading/1.0.0-2.0.0.md
@@ -19,8 +19,6 @@ class HostComponent {
   readonly container = viewChild('host', { read: ViewContainerRef });
 
   createIcon() {
-    if (!this.container()) { return; }
-
     const componentRef = this.container().createComponent(FaIconComponent);
 -    componentRef.instance.icon = faUser;
 -    componentRef.instance.render();
@@ -43,8 +41,8 @@ class HostComponent {
 
   spinIcon() {
     const iconComponent = this.iconComponent();
--    iconComponent?.animation = 'spin';
-+    iconComponent?.animation.set('spin');
+-    iconComponent.animation = 'spin';
++    iconComponent.animation.set('spin');
   }
 }
 ```

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -209,8 +209,6 @@ class HostComponent {
   readonly container = viewChild('host', { read: ViewContainerRef });
 
   createIcon() {
-    if (!this.countainer()) { return; }
-
     const componentRef = this.countainer().createComponent(FaIconComponent);
     componentRef.setInput('icon', faUser);
   }
@@ -229,7 +227,7 @@ class HostComponent {
   readonly iconComponent = viewChild(FaIconComponent);
 
   spinIcon() {
-    this.iconComponent()?.animation.set('spin');
+    this.iconComponent().animation.set('spin');
   }
 }
 ```

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -209,11 +209,10 @@ class HostComponent {
   readonly container = viewChild('host', { read: ViewContainerRef });
 
   createIcon() {
-    const container = this.container();
-    if (!container) { return; }
+    if (!this.countainer()) { return; }
 
-    const componentRef = container.createComponent(FaIconComponent);
-    componentRef.setInput('icon', faUser); // no need to call render function now
+    const componentRef = this.countainer().createComponent(FaIconComponent);
+    componentRef.setInput('icon', faUser);
   }
 }
 ```
@@ -230,8 +229,7 @@ class HostComponent {
   readonly iconComponent = viewChild(FaIconComponent);
 
   spinIcon() {
-    const iconComponent = this.iconComponent();
-    this.iconComponent?.animation.set('spin');
+    this.iconComponent()?.animation.set('spin');
   }
 }
 ```

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -190,6 +190,52 @@ When using standalone components, make sure to also add `FaStackItemSizeDirectiv
 
 ### Programmatic API
 
+#### v2.0.0 Onwards
+
+To create `FaIconComponent` dynamically:
+
+```ts
+@Component({
+  selector: 'fa-host',
+  template: `
+    <button (click)="createIcon()">
+      Create
+    </button>
+    <br>
+    <ng-container #host></ng-container>
+  `
+})
+class HostComponent {
+  readonly container = viewChild('host', { read: ViewContainerRef });
+
+  createIcon() {
+    const container = this.container();
+    if (!container) { return; }
+
+    const componentRef = container.createComponent(FaIconComponent);
+    componentRef.setInput('icon', faUser); // no need to call render function now
+  }
+}
+```
+
+To update `FaIconComponent` programmatically:
+
+```ts
+@Component({
+  selector: 'fa-host',
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+})
+class HostComponent {
+  readonly faUser = faUser;
+  readonly iconComponent = viewChild(FaIconComponent);
+
+  spinIcon() {
+    const iconComponent = this.iconComponent();
+    this.iconComponent?.animation.set('spin');
+  }
+}
+```
+
 #### Upto v1.0.0
 
 To create `FaIconComponent` dynamically:
@@ -229,58 +275,6 @@ class HostComponent {
     // Note that FaIconComponent.render() should be called to update the
     // rendered SVG after setting/updating component inputs.
     this.iconComponent.render();
-  }
-}
-```
-
-#### v1.1.0 Onwards
-
-To create `FaIconComponent` dynamically:
-
-```ts
-@Component({
-  selector: 'fa-host',
-  template: `
-    <button (click)="createIcon()">
-      Create
-    </button>
-    <br>
-    <ng-container #host></ng-container>
-  `
-})
-class HostComponent {
-  readonly container = viewChild('host', { static: true, read: ViewContainerRef });
-
-  createIcon() {
-    const container = this.container();
-    if (!container) {
-      return;
-    }
-
-    const componentRef = container.createComponent(FaIconComponent);
-    componentRef.setInput('icon', faUser); // no need to call render function now
-  }
-}
-```
-
-To update `FaIconComponent` programmatically:
-
-```ts
-@Component({
-  selector: 'fa-host',
-  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
-})
-class HostComponent {
-  readonly faUser = faUser;
-  readonly iconComponent = viewChild(FaIconComponent, { static: true });
-
-  spinIcon() {
-    const iconComponent = this.iconComponent();
-    if (!container) {
-      return;
-    }
-
-    this.iconComponent.animation.set('spin');
   }
 }
 ```

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -190,6 +190,8 @@ When using standalone components, make sure to also add `FaStackItemSizeDirectiv
 
 ### Programmatic API
 
+#### Upto v1.0.0
+
 To create `FaIconComponent` dynamically:
 
 ```ts
@@ -227,6 +229,58 @@ class HostComponent {
     // Note that FaIconComponent.render() should be called to update the
     // rendered SVG after setting/updating component inputs.
     this.iconComponent.render();
+  }
+}
+```
+
+#### v1.1.0 Onwards
+
+To create `FaIconComponent` dynamically:
+
+```ts
+@Component({
+  selector: 'fa-host',
+  template: `
+    <button (click)="createIcon()">
+      Create
+    </button>
+    <br>
+    <ng-container #host></ng-container>
+  `
+})
+class HostComponent {
+  readonly container = viewChild('host', { static: true, read: ViewContainerRef });
+
+  createIcon() {
+    const container = this.container();
+    if (!container) {
+      return;
+    }
+
+    const componentRef = container.createComponent(FaIconComponent);
+    componentRef.setInput('icon', faUser); // no need to call render function now
+  }
+}
+```
+
+To update `FaIconComponent` programmatically:
+
+```ts
+@Component({
+  selector: 'fa-host',
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+})
+class HostComponent {
+  readonly faUser = faUser;
+  readonly iconComponent = viewChild(FaIconComponent, { static: true });
+
+  spinIcon() {
+    const iconComponent = this.iconComponent();
+    if (!container) {
+      return;
+    }
+
+    this.iconComponent.animation.set('spin');
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Angular Fontawesome, an Angular library",
   "scripts": {
+    "ng": "ng",
     "test": "ng test angular-fontawesome --watch=false --browsers=ChromeCI",
     "test:schematics": "ts-node --project projects/schematics/tsconfig.json node_modules/.bin/jasmine projects/schematics/src/**/*.spec.ts",
     "test:demo": "ng test demo --watch=false --browsers=ChromeCI",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fortawesome/angular-fontawesome",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Angular Fontawesome, an Angular library",
   "scripts": {
     "ng": "ng",

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,18 +1,6 @@
 import { DecimalPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import {
-  FaConfig,
-  FaDuotoneIconComponent,
-  FaIconComponent,
-  FaIconLibrary,
-  FaLayersComponent,
-  FaLayersCounterComponent,
-  FaLayersTextComponent,
-  FaStackComponent,
-  FaStackItemSizeDirective,
-  FontAwesomeModule,
-  IconDefinition,
-} from '@fortawesome/angular-fontawesome';
+import { FaConfig, FaIconLibrary, FontAwesomeModule, IconDefinition } from '@fortawesome/angular-fontawesome';
 import { faFlag, faUser as regularUser } from '@fortawesome/free-regular-svg-icons';
 import {
   faAdjust,
@@ -35,18 +23,7 @@ import { AlternatePrefixComponent } from './alternate-prefix.component';
 
 @Component({
   selector: 'app-root',
-  imports: [
-    DecimalPipe,
-    FontAwesomeModule,
-    AlternatePrefixComponent,
-    FaIconComponent,
-    FaDuotoneIconComponent,
-    FaLayersComponent,
-    FaStackItemSizeDirective,
-    FaStackComponent,
-    FaLayersCounterComponent,
-    FaLayersTextComponent,
-  ],
+  imports: [DecimalPipe, FontAwesomeModule, AlternatePrefixComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { DecimalPipe } from '@angular/common';
-import { Component } from '@angular/core';
-import { FaConfig, FaIconLibrary, FontAwesomeModule, IconDefinition } from '@fortawesome/angular-fontawesome';
+import { Component, inject } from '@angular/core';
+import { FaConfig, FaDuotoneIconComponent, FaIconComponent, FaIconLibrary, FaLayersComponent, FaLayersCounterComponent, FaLayersTextComponent, FaStackComponent, FaStackItemSizeDirective, FontAwesomeModule, IconDefinition } from '@fortawesome/angular-fontawesome';
 import { faFlag, faUser as regularUser } from '@fortawesome/free-regular-svg-icons';
 import {
   faAdjust,
@@ -23,7 +23,18 @@ import { AlternatePrefixComponent } from './alternate-prefix.component';
 
 @Component({
   selector: 'app-root',
-  imports: [DecimalPipe, FontAwesomeModule, AlternatePrefixComponent],
+  imports: [
+    DecimalPipe,
+    FontAwesomeModule,
+    AlternatePrefixComponent,
+    FaIconComponent,
+    FaDuotoneIconComponent,
+    FaLayersComponent,
+    FaStackItemSizeDirective,
+    FaStackComponent,
+    FaLayersCounterComponent,
+    FaLayersTextComponent,
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
@@ -56,7 +67,7 @@ export class AppComponent {
 
   selectedPosition: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
 
-  constructor(library: FaIconLibrary, faConfig: FaConfig) {
+  constructor() {
     // Notice that we're adding two different icon objects to the library.
     // Each of them within their respective icon npm packages are exported as faUser,
     // but we've renamed the second one in order to disambiguate the two objects within
@@ -76,8 +87,8 @@ export class AppComponent {
     // <fa-icon [icon]="regularUser"></fa-icon>
     //
     // You don't specify the prefix in that case, because the icon object knows its own prefix.
-    library.addIcons(faUser, regularUser);
-    faConfig.fallbackIcon = faMagic;
+    inject(FaIconLibrary).addIcons(faUser, regularUser);
+    inject(FaConfig).fallbackIcon = faMagic;
   }
 
   onChange(event: any) {

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,6 +1,18 @@
 import { DecimalPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import { FaConfig, FaDuotoneIconComponent, FaIconComponent, FaIconLibrary, FaLayersComponent, FaLayersCounterComponent, FaLayersTextComponent, FaStackComponent, FaStackItemSizeDirective, FontAwesomeModule, IconDefinition } from '@fortawesome/angular-fontawesome';
+import {
+  FaConfig,
+  FaDuotoneIconComponent,
+  FaIconComponent,
+  FaIconLibrary,
+  FaLayersComponent,
+  FaLayersCounterComponent,
+  FaLayersTextComponent,
+  FaStackComponent,
+  FaStackItemSizeDirective,
+  FontAwesomeModule,
+  IconDefinition,
+} from '@fortawesome/angular-fontawesome';
 import { faFlag, faUser as regularUser } from '@fortawesome/free-regular-svg-icons';
 import {
   faAdjust,

--- a/projects/demo/src/app/app.config.ts
+++ b/projects/demo/src/app/app.config.ts
@@ -1,8 +1,5 @@
 import { ApplicationConfig } from '@angular/core';
-import { provideRouter } from '@angular/router';
-
-import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes)],
+  providers: [],
 };

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -1,3 +1,0 @@
-import { Routes } from '@angular/router';
-
-export const routes: Routes = [];

--- a/projects/schematics/src/ng-add/versions.ts
+++ b/projects/schematics/src/ng-add/versions.ts
@@ -1,4 +1,4 @@
-export const angularFontawesomeVersion = '^1.0.0';
+export const angularFontawesomeVersion = '^2.0.0';
 export const iconPackVersion = '^6.7.1';
 
 export const v5 = {

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -32,4 +32,4 @@ import { FaStackComponent } from './stack/stack.component';
     FaStackItemSizeDirective,
   ],
 })
-export class FontAwesomeModule { }
+export class FontAwesomeModule {}

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -7,6 +7,11 @@ import { FaLayersComponent } from './layers/layers.component';
 import { FaStackItemSizeDirective } from './stack/stack-item-size.directive';
 import { FaStackComponent } from './stack/stack.component';
 
+/**
+ * @deprecated
+ * This module is deprecated and will be removed in the next major version.
+ * Instae use the standalone components directly in component import
+ */
 @NgModule({
   imports: [
     FaIconComponent,
@@ -27,4 +32,4 @@ import { FaStackComponent } from './stack/stack.component';
     FaStackItemSizeDirective,
   ],
 })
-export class FontAwesomeModule {}
+export class FontAwesomeModule { }

--- a/src/lib/fontawesome.module.ts
+++ b/src/lib/fontawesome.module.ts
@@ -7,11 +7,6 @@ import { FaLayersComponent } from './layers/layers.component';
 import { FaStackItemSizeDirective } from './stack/stack-item-size.directive';
 import { FaStackComponent } from './stack/stack.component';
 
-/**
- * @deprecated
- * This module is deprecated and will be removed in the next major version.
- * Instae use the standalone components directly in component import
- */
 @NgModule({
   imports: [
     FaIconComponent,

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -126,7 +126,6 @@ describe('FaDuotoneIconComponent', () => {
       createIcon() {
         const componentRef = this.container.createComponent(FaDuotoneIconComponent);
         componentRef.setInput('icon', faDummy);
-        componentRef.instance.render();
       }
     }
 

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, signal, ViewChild, ViewContainerRef } from '@angular/core';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { faDummy, initTest, queryByCss } from '../../testing/helpers';
 import { FaDuotoneIconComponent } from './duotone-icon.component';
@@ -8,10 +8,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -23,10 +23,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy" [swapOpacity]="true"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [swapOpacity]="true"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -38,10 +38,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy" [primaryOpacity]="0.1"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [primaryOpacity]="0.1"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -53,10 +53,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy" [secondaryOpacity]="0.9"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [secondaryOpacity]="0.9"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -68,10 +68,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy" primaryColor="red"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" primaryColor="red"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -83,10 +83,10 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy" secondaryColor="red"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" secondaryColor="red"></fa-duotone-icon>',
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -98,18 +98,18 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faUser"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faUser()"></fa-duotone-icon>',
     })
     class HostComponent {
-      faUser = faUser;
+      faUser = signal(faUser);
     }
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
-          'or use: <fa-icon icon="user"></fa-icon> instead.',
+        "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
+        'or use: <fa-icon icon="user"></fa-icon> instead.',
       ),
     );
   });

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -108,8 +108,8 @@ describe('FaDuotoneIconComponent', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-        "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
-        'or use: <fa-icon icon="user"></fa-icon> instead.',
+          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
+          'or use: <fa-icon icon="user"></fa-icon> instead.',
       ),
     );
   });

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -108,8 +108,8 @@ describe('FaDuotoneIconComponent', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
-          'or use: <fa-icon icon="user"></fa-icon> instead.',
+        "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
+        'or use: <fa-icon icon="user"></fa-icon> instead.',
       ),
     );
   });
@@ -125,7 +125,7 @@ describe('FaDuotoneIconComponent', () => {
 
       createIcon() {
         const componentRef = this.container.createComponent(FaDuotoneIconComponent);
-        componentRef.instance.icon = faDummy;
+        componentRef.setInput('icon', faDummy);
         componentRef.instance.render();
       }
     }

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -55,9 +55,9 @@ export class FaDuotoneIconComponent extends FaIconComponent {
     if (definition != null && !Array.isArray(definition.icon[4])) {
       throw new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-          'Check that you specified the correct style: ' +
-          `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
-          `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
+        'Check that you specified the correct style: ' +
+        `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
+        `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
       );
     }
 

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -81,16 +81,16 @@ export class FaDuotoneIconComponent extends FaIconComponent {
     if (params.styles == null) {
       params.styles = {};
     }
-    if (this.primaryOpacity != null) {
+    if (this.primaryOpacity() != null) {
       params.styles['--fa-primary-opacity'] = this.primaryOpacity().toString();
     }
-    if (this.secondaryOpacity != null) {
+    if (this.secondaryOpacity() != null) {
       params.styles['--fa-secondary-opacity'] = this.secondaryOpacity().toString();
     }
-    if (this.primaryColor != null) {
+    if (this.primaryColor() != null) {
       params.styles['--fa-primary-color'] = this.primaryColor();
     }
-    if (this.secondaryColor != null) {
+    if (this.secondaryColor() != null) {
       params.styles['--fa-secondary-color'] = this.secondaryColor();
     }
 

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { IconDefinition as CoreIconDefinition, IconParams } from '@fortawesome/fontawesome-svg-core';
 import { IconDefinition, IconProp } from '../types';
 import { FaIconComponent } from './icon.component';
@@ -6,6 +6,7 @@ import { FaIconComponent } from './icon.component';
 @Component({
   selector: 'fa-duotone-icon',
   template: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaDuotoneIconComponent extends FaIconComponent {
   /**

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { IconDefinition as CoreIconDefinition, IconParams } from '@fortawesome/fontawesome-svg-core';
 import { IconDefinition, IconProp } from '../types';
 import { FaIconComponent } from './icon.component';
@@ -15,7 +15,7 @@ export class FaDuotoneIconComponent extends FaIconComponent {
    *
    * @default false
    */
-  @Input() swapOpacity?: 'true' | 'false' | boolean;
+  readonly swapOpacity = input<'true' | 'false' | boolean>();
 
   /**
    * Customize the opacity of the primary icon layer.
@@ -23,7 +23,7 @@ export class FaDuotoneIconComponent extends FaIconComponent {
    *
    * @default 1.0
    */
-  @Input() primaryOpacity?: string | number;
+  readonly primaryOpacity = input<string | number>();
 
   /**
    * Customize the opacity of the secondary icon layer.
@@ -31,7 +31,7 @@ export class FaDuotoneIconComponent extends FaIconComponent {
    *
    * @default 0.4
    */
-  @Input() secondaryOpacity?: string | number;
+  readonly secondaryOpacity = input<string | number>();
 
   /**
    * Customize the color of the primary icon layer.
@@ -39,7 +39,7 @@ export class FaDuotoneIconComponent extends FaIconComponent {
    *
    * @default CSS inherited color
    */
-  @Input() primaryColor?: string;
+  readonly primaryColor = input<string>();
 
   /**
    * Customize the color of the secondary icon layer.
@@ -47,7 +47,7 @@ export class FaDuotoneIconComponent extends FaIconComponent {
    *
    * @default CSS inherited color
    */
-  @Input() secondaryColor?: string;
+  readonly secondaryColor = input<string>();
 
   protected findIconDefinition(i: IconProp | IconDefinition): CoreIconDefinition | null {
     const definition = super.findIconDefinition(i);
@@ -67,7 +67,8 @@ export class FaDuotoneIconComponent extends FaIconComponent {
   protected buildParams(): IconParams {
     const params = super.buildParams();
 
-    if (this.swapOpacity === true || this.swapOpacity === 'true') {
+    const swapOpacity = this.swapOpacity();
+    if (swapOpacity === true || swapOpacity === 'true') {
       if (Array.isArray(params.classes)) {
         params.classes.push('fa-swap-opacity');
       } else if (typeof params.classes === 'string') {
@@ -81,16 +82,16 @@ export class FaDuotoneIconComponent extends FaIconComponent {
       params.styles = {};
     }
     if (this.primaryOpacity != null) {
-      params.styles['--fa-primary-opacity'] = this.primaryOpacity.toString();
+      params.styles['--fa-primary-opacity'] = this.primaryOpacity().toString();
     }
     if (this.secondaryOpacity != null) {
-      params.styles['--fa-secondary-opacity'] = this.secondaryOpacity.toString();
+      params.styles['--fa-secondary-opacity'] = this.secondaryOpacity().toString();
     }
     if (this.primaryColor != null) {
-      params.styles['--fa-primary-color'] = this.primaryColor;
+      params.styles['--fa-primary-color'] = this.primaryColor();
     }
     if (this.secondaryColor != null) {
-      params.styles['--fa-secondary-color'] = this.secondaryColor;
+      params.styles['--fa-secondary-color'] = this.secondaryColor();
     }
 
     return params;

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -55,9 +55,9 @@ export class FaDuotoneIconComponent extends FaIconComponent {
     if (definition != null && !Array.isArray(definition.icon[4])) {
       throw new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-        'Check that you specified the correct style: ' +
-        `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
-        `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
+          'Check that you specified the correct style: ' +
+          `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
+          `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
       );
     }
 

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -1,4 +1,5 @@
 import { Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
 import { TestBed } from '@angular/core/testing';
 import { faUser as faUserRegular } from '@fortawesome/free-regular-svg-icons';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
@@ -57,7 +58,7 @@ describe('FaIconComponent', () => {
 
       createIcon() {
         const componentRef = this.container.createComponent(FaIconComponent);
-        componentRef.instance.icon = faUser;
+        componentRef.setInput('icon', faUser);
         componentRef.instance.render();
       }
     }
@@ -87,7 +88,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeFalsy();
 
-    fixture.componentInstance.iconComponent.animation = 'spin';
+    signalSetFn(fixture.componentInstance.iconComponent.animation[SIGNAL], 'spin');
     fixture.componentInstance.iconComponent.render();
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeTruthy();
@@ -114,7 +115,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon [icon]="undefined"></fa-icon>',
     })
-    class HostComponent {}
+    class HostComponent { }
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -311,7 +312,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon icon="circle"></fa-icon>',
     })
-    class HostComponent {}
+    class HostComponent { }
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -375,7 +376,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(spy).toHaveBeenCalledWith(
       'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+      'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
     );
   });
 

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -1,5 +1,4 @@
 import { Component, ViewChild, ViewContainerRef } from '@angular/core';
-import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
 import { TestBed } from '@angular/core/testing';
 import { faUser as faUserRegular } from '@fortawesome/free-regular-svg-icons';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
@@ -59,7 +58,6 @@ describe('FaIconComponent', () => {
       createIcon() {
         const componentRef = this.container.createComponent(FaIconComponent);
         componentRef.setInput('icon', faUser);
-        componentRef.instance.render();
       }
     }
 
@@ -88,8 +86,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeFalsy();
 
-    signalSetFn(fixture.componentInstance.iconComponent.animation[SIGNAL], 'spin');
-    fixture.componentInstance.iconComponent.render();
+    fixture.componentInstance.iconComponent.animation.set('spin');
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeTruthy();
   });

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -9,7 +9,6 @@ import { FaConfig } from '../config';
 import { FaIconLibrary } from '../icon-library';
 import { IconProp } from '../types';
 import { FaIconComponent } from './icon.component';
-import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
 
 describe('FaIconComponent', () => {
   it('should render SVG icon', () => {
@@ -87,7 +86,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeFalsy();
 
-    signalSetFn(fixture.componentInstance.iconComponent.animation[SIGNAL], 'spin');
+    fixture.componentInstance.iconComponent.animation.set('spin');
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeTruthy();
   });

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -9,6 +9,7 @@ import { FaConfig } from '../config';
 import { FaIconLibrary } from '../icon-library';
 import { IconProp } from '../types';
 import { FaIconComponent } from './icon.component';
+import { SIGNAL, signalSetFn } from '@angular/core/primitives/signals';
 
 describe('FaIconComponent', () => {
   it('should render SVG icon', () => {
@@ -86,7 +87,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeFalsy();
 
-    fixture.componentInstance.iconComponent.animation.set('spin');
+    signalSetFn(fixture.componentInstance.iconComponent.animation[SIGNAL], 'spin');
     fixture.detectChanges();
     expect(queryByCss(fixture, 'svg').classList.contains('fa-spin')).toBeTruthy();
   });

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -115,7 +115,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon [icon]="undefined"></fa-icon>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -312,7 +312,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon icon="circle"></fa-icon>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -376,7 +376,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(spy).toHaveBeenCalledWith(
       'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-      'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
     );
   });
 

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, signal, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, signal, viewChild, ViewChild, ViewContainerRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { faUser as faUserRegular } from '@fortawesome/free-regular-svg-icons';
@@ -54,10 +54,10 @@ describe('FaIconComponent', () => {
       template: '<ng-container #host></ng-container>',
     })
     class HostComponent {
-      @ViewChild('host', { static: true, read: ViewContainerRef }) container: ViewContainerRef;
+      container = viewChild('host', { read: ViewContainerRef });
 
       createIcon() {
-        const componentRef = this.container.createComponent(FaIconComponent);
+        const componentRef = this.container().createComponent(FaIconComponent);
         componentRef.setInput('icon', faUser);
       }
     }

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -113,7 +113,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon [icon]="undefined"></fa-icon>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -334,7 +334,7 @@ describe('FaIconComponent', () => {
       standalone: false,
       template: '<fa-icon icon="circle"></fa-icon>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     expect(() => fixture.detectChanges()).toThrow(
@@ -398,7 +398,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(spy).toHaveBeenCalledWith(
       'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-      'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
     );
   });
 

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, OnChanges, SimpleChanges, input } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FaSymbol,
@@ -31,11 +31,11 @@ import { IconDefinition, IconProp } from '../types';
   template: ``,
   host: {
     class: 'ng-fa-icon',
-    '[attr.title]': 'title',
+    '[attr.title]': 'title()',
   },
 })
 export class FaIconComponent implements OnChanges {
-  @Input() icon: IconProp;
+  readonly icon = input.required<IconProp>();
 
   /**
    * Specify a title for the icon.
@@ -43,7 +43,7 @@ export class FaIconComponent implements OnChanges {
    * This text will be displayed in a tooltip on hover and presented to the
    * screen readers.
    */
-  @Input() title?: string;
+  readonly title = input<string>();
 
   /**
    * Icon animation.
@@ -51,25 +51,25 @@ export class FaIconComponent implements OnChanges {
    * Most of the animations are only available when using Font Awesome 6. With
    * Font Awesome 5, only 'spin' and 'spin-pulse' are supported.
    */
-  @Input() animation?: AnimationProp;
+  readonly animation = input<AnimationProp>();
 
-  @Input() mask?: IconProp;
-  @Input() flip?: FlipProp;
-  @Input() size?: SizeProp;
-  @Input() pull?: PullProp;
-  @Input() border?: boolean;
-  @Input() inverse?: boolean;
-  @Input() symbol?: FaSymbol;
-  @Input() rotate?: RotateProp | string;
-  @Input() fixedWidth?: boolean;
-  @Input() transform?: string | Transform;
+  readonly mask = input<IconProp>();
+  readonly flip = input<FlipProp>();
+  readonly size = input<SizeProp>();
+  readonly pull = input<PullProp>();
+  readonly border = input<boolean>();
+  readonly inverse = input<boolean>();
+  readonly symbol = input<FaSymbol>();
+  readonly rotate = input<RotateProp | string>();
+  readonly fixedWidth = input<boolean>();
+  readonly transform = input<string | Transform>();
 
   /**
    * Specify the `role` attribute for the rendered <svg> element.
    *
    * @default 'img'
    */
-  @Input() a11yRole: string;
+  readonly a11yRole = input<string>();
 
   @HostBinding('innerHTML') renderedIconHTML: SafeHtml;
 
@@ -90,13 +90,14 @@ export class FaIconComponent implements OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (this.icon == null && this.config.fallbackIcon == null) {
+    const iconValue = this.icon();
+    if (iconValue == null && this.config.fallbackIcon == null) {
       faWarnIfIconSpecMissing();
       return;
     }
 
     if (changes) {
-      const iconDefinition = this.findIconDefinition(this.icon ?? this.config.fallbackIcon);
+      const iconDefinition = this.findIconDefinition(iconValue ?? this.config.fallbackIcon);
       if (iconDefinition != null) {
         const params = this.buildParams();
         ensureCss(this.document, this.config);
@@ -133,19 +134,21 @@ export class FaIconComponent implements OnChanges {
   }
 
   protected buildParams(): IconParams {
+    const fixedWidth = this.fixedWidth();
     const classOpts: FaProps = {
-      flip: this.flip,
-      animation: this.animation,
-      border: this.border,
-      inverse: this.inverse,
-      size: this.size || null,
-      pull: this.pull || null,
-      rotate: this.rotate || null,
-      fixedWidth: typeof this.fixedWidth === 'boolean' ? this.fixedWidth : this.config.fixedWidth,
-      stackItemSize: this.stackItem != null ? this.stackItem.stackItemSize : null,
+      flip: this.flip(),
+      animation: this.animation(),
+      border: this.border(),
+      inverse: this.inverse(),
+      size: this.size() || null,
+      pull: this.pull() || null,
+      rotate: this.rotate() || null,
+      fixedWidth: typeof fixedWidth === 'boolean' ? fixedWidth : this.config.fixedWidth,
+      stackItemSize: this.stackItem != null ? this.stackItem.stackItemSize() : null,
     };
 
-    const parsedTransform = typeof this.transform === 'string' ? parse.transform(this.transform) : this.transform;
+    const transform = this.transform();
+    const parsedTransform = typeof transform === 'string' ? parse.transform(transform) : transform;
 
     const styles: Styles = {};
     if (classOpts.rotate != null && !isKnownRotateValue(classOpts.rotate)) {
@@ -153,13 +156,13 @@ export class FaIconComponent implements OnChanges {
     }
 
     return {
-      title: this.title,
+      title: this.title(),
       transform: parsedTransform,
       classes: faClassList(classOpts),
-      mask: this.mask != null ? this.findIconDefinition(this.mask) : null,
-      symbol: this.symbol,
+      mask: this.mask != null ? this.findIconDefinition(this.mask()) : null,
+      symbol: this.symbol(),
       attributes: {
-        role: this.a11yRole,
+        role: this.a11yRole(),
       },
       styles,
     };

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -84,7 +84,7 @@ export class FaIconComponent implements OnChanges {
     if (this.stack != null && this.stackItem == null) {
       console.error(
         'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+          'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
       );
     }
   }

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, input, model, computed } from '@angular/core';
+import { Component, inject, input, computed } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FaSymbol,
@@ -36,7 +36,7 @@ import { IconDefinition, IconProp } from '../types';
   },
 })
 export class FaIconComponent {
-  readonly icon = model.required<IconProp>();
+  readonly icon = input.required<IconProp>();
 
   /**
    * Specify a title for the icon.
@@ -44,7 +44,7 @@ export class FaIconComponent {
    * This text will be displayed in a tooltip on hover and presented to the
    * screen readers.
    */
-  readonly title = model<string>();
+  readonly title = input<string>();
 
   /**
    * Icon animation.
@@ -52,17 +52,17 @@ export class FaIconComponent {
    * Most of the animations are only available when using Font Awesome 6. With
    * Font Awesome 5, only 'spin' and 'spin-pulse' are supported.
    */
-  readonly animation = model<AnimationProp>();
+  readonly animation = input<AnimationProp>();
 
-  readonly mask = model<IconProp>();
-  readonly flip = model<FlipProp>();
-  readonly size = model<SizeProp>();
-  readonly pull = model<PullProp>();
-  readonly border = model<boolean>();
-  readonly inverse = model<boolean>();
-  readonly symbol = model<FaSymbol>();
-  readonly rotate = model<RotateProp | string>();
-  readonly fixedWidth = model<boolean>();
+  readonly mask = input<IconProp>();
+  readonly flip = input<FlipProp>();
+  readonly size = input<SizeProp>();
+  readonly pull = input<PullProp>();
+  readonly border = input<boolean>();
+  readonly inverse = input<boolean>();
+  readonly symbol = input<FaSymbol>();
+  readonly rotate = input<RotateProp | string>();
+  readonly fixedWidth = input<boolean>();
   readonly transform = input<string | Transform>();
 
   /**

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -159,7 +159,7 @@ export class FaIconComponent implements OnChanges {
       title: this.title(),
       transform: parsedTransform,
       classes: faClassList(classOpts),
-      mask: this.mask != null ? this.findIconDefinition(this.mask()) : null,
+      mask: this.mask() != null ? this.findIconDefinition(this.mask()) : null,
       symbol: this.symbol(),
       attributes: {
         role: this.a11yRole(),

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, Optional, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FaSymbol,
@@ -73,19 +73,18 @@ export class FaIconComponent implements OnChanges {
 
   @HostBinding('innerHTML') renderedIconHTML: SafeHtml;
 
-  private document = inject(DOCUMENT);
+  private readonly document = inject(DOCUMENT);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly config = inject(FaConfig);
+  private readonly iconLibrary = inject(FaIconLibrary);
+  private readonly stackItem = inject(FaStackItemSizeDirective, { optional: true });
+  private readonly stack = inject(FaStackComponent, { optional: true });
 
-  constructor(
-    private sanitizer: DomSanitizer,
-    private config: FaConfig,
-    private iconLibrary: FaIconLibrary,
-    @Optional() private stackItem: FaStackItemSizeDirective,
-    @Optional() stack: FaStackComponent,
-  ) {
-    if (stack != null && stackItem == null) {
+  constructor() {
+    if (this.stack != null && this.stackItem == null) {
       console.error(
         'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-          'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
       );
     }
   }

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, input, computed } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, inject, computed, model, ChangeDetectionStrategy } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import {
   FaSymbol,
   FlipProp,
@@ -34,9 +34,10 @@ import { IconDefinition, IconProp } from '../types';
     '[attr.title]': 'title()',
     '[innerHTML]': 'renderedIconHTML()',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaIconComponent {
-  readonly icon = input.required<IconProp>();
+  readonly icon = model.required<IconProp>();
 
   /**
    * Specify a title for the icon.
@@ -44,7 +45,7 @@ export class FaIconComponent {
    * This text will be displayed in a tooltip on hover and presented to the
    * screen readers.
    */
-  readonly title = input<string>();
+  readonly title = model<string>();
 
   /**
    * Icon animation.
@@ -52,27 +53,27 @@ export class FaIconComponent {
    * Most of the animations are only available when using Font Awesome 6. With
    * Font Awesome 5, only 'spin' and 'spin-pulse' are supported.
    */
-  readonly animation = input<AnimationProp>();
+  readonly animation = model<AnimationProp>();
 
-  readonly mask = input<IconProp>();
-  readonly flip = input<FlipProp>();
-  readonly size = input<SizeProp>();
-  readonly pull = input<PullProp>();
-  readonly border = input<boolean>();
-  readonly inverse = input<boolean>();
-  readonly symbol = input<FaSymbol>();
-  readonly rotate = input<RotateProp | string>();
-  readonly fixedWidth = input<boolean>();
-  readonly transform = input<string | Transform>();
+  readonly mask = model<IconProp>();
+  readonly flip = model<FlipProp>();
+  readonly size = model<SizeProp>();
+  readonly pull = model<PullProp>();
+  readonly border = model<boolean>();
+  readonly inverse = model<boolean>();
+  readonly symbol = model<FaSymbol>();
+  readonly rotate = model<RotateProp | string>();
+  readonly fixedWidth = model<boolean>();
+  readonly transform = model<string | Transform>();
 
   /**
    * Specify the `role` attribute for the rendered <svg> element.
    *
    * @default 'img'
    */
-  readonly a11yRole = input<string>();
+  readonly a11yRole = model<string>();
 
-  renderedIconHTML = computed<SafeHtml | ''>(() => {
+  readonly renderedIconHTML = computed(() => {
     const iconValue = this.icon();
     if (iconValue == null && this.config.fallbackIcon == null) {
       faWarnIfIconSpecMissing();

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, OnChanges, SimpleChanges, input } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { counter, CounterParams } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
@@ -15,9 +15,9 @@ import { FaLayersComponent } from './layers.component';
   },
 })
 export class FaLayersCounterComponent implements OnChanges {
-  @Input() content: string;
-  @Input() title?: string;
-  @Input() position?: 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+  readonly content = input.required<string>();
+  readonly title = input<string>();
+  readonly position = input<'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'>();
 
   @HostBinding('innerHTML') renderedHTML: SafeHtml;
 
@@ -39,13 +39,13 @@ export class FaLayersCounterComponent implements OnChanges {
 
   protected buildParams(): CounterParams {
     return {
-      title: this.title,
-      classes: this.position != null ? [`fa-layers-${this.position}`] : undefined,
+      title: this.title(),
+      classes: this.position != null ? [`fa-layers-${this.position()}`] : undefined,
     };
   }
 
   private updateContent(params: CounterParams) {
     ensureCss(this.document, this.config);
-    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(counter(this.content || '', params).html.join(''));
+    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(counter(this.content() || '', params).html.join(''));
   }
 }

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, OnChanges, SimpleChanges, input } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, inject, input, computed } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { counter, CounterParams } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
 import { faWarnIfParentNotExist } from '../shared/errors/warn-if-parent-not-exist';
@@ -12,14 +12,18 @@ import { FaLayersComponent } from './layers.component';
   template: '',
   host: {
     class: 'ng-fa-layers-counter',
+    '[innerHTML]': 'renderedHTML()',
   },
 })
-export class FaLayersCounterComponent implements OnChanges {
+export class FaLayersCounterComponent {
   readonly content = input.required<string>();
   readonly title = input<string>();
   readonly position = input<'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'>();
 
-  @HostBinding('innerHTML') renderedHTML: SafeHtml;
+  renderedHTML = computed(() => {
+    const params = this.buildParams();
+    return this.updateContent(params);
+  });
 
   private document = inject(DOCUMENT);
   private config = inject(FaConfig);
@@ -28,13 +32,6 @@ export class FaLayersCounterComponent implements OnChanges {
 
   constructor() {
     faWarnIfParentNotExist(this.parent, 'FaLayersComponent', this.constructor.name);
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes) {
-      const params = this.buildParams();
-      this.updateContent(params);
-    }
   }
 
   protected buildParams(): CounterParams {
@@ -47,6 +44,6 @@ export class FaLayersCounterComponent implements OnChanges {
 
   private updateContent(params: CounterParams) {
     ensureCss(this.document, this.config);
-    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(counter(this.content() || '', params).html.join(''));
+    return this.sanitizer.bypassSecurityTrustHtml(counter(this.content() || '', params).html.join(''));
   }
 }

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, Optional, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { counter, CounterParams } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
@@ -23,11 +23,10 @@ export class FaLayersCounterComponent implements OnChanges {
 
   private document = inject(DOCUMENT);
   private config = inject(FaConfig);
+  private parent = inject(FaLayersComponent, { optional: true });
+  private sanitizer = inject(DomSanitizer);
 
-  constructor(
-    @Optional() private parent: FaLayersComponent,
-    private sanitizer: DomSanitizer,
-  ) {
+  constructor() {
     faWarnIfParentNotExist(this.parent, 'FaLayersComponent', this.constructor.name);
   }
 

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -38,9 +38,10 @@ export class FaLayersCounterComponent implements OnChanges {
   }
 
   protected buildParams(): CounterParams {
+    const position = this.position();
     return {
       title: this.title(),
-      classes: this.position != null ? [`fa-layers-${this.position()}`] : undefined,
+      classes: position != null ? [`fa-layers-${position}`] : undefined,
     };
   }
 

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -20,7 +20,7 @@ export class FaLayersCounterComponent {
   readonly title = input<string>();
   readonly position = input<'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'>();
 
-  renderedHTML = computed(() => {
+  readonly renderedHTML = computed(() => {
     const params = this.buildParams();
     return this.updateContent(params);
   });

--- a/src/lib/layers/layers-counter.component.ts
+++ b/src/lib/layers/layers-counter.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, input, computed } from '@angular/core';
+import { Component, inject, input, computed, ChangeDetectionStrategy } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { counter, CounterParams } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
@@ -14,6 +14,7 @@ import { FaLayersComponent } from './layers.component';
     class: 'ng-fa-layers-counter',
     '[innerHTML]': 'renderedHTML()',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaLayersCounterComponent {
   readonly content = input.required<string>();

--- a/src/lib/layers/layers-text.component.ts
+++ b/src/lib/layers/layers-text.component.ts
@@ -39,7 +39,7 @@ export class FaLayersTextComponent {
   readonly fixedWidth = input<boolean>();
   readonly transform = input<string | Transform>();
 
-  renderedHTML = computed(() => {
+  readonly renderedHTML = computed(() => {
     const params = this.buildParams();
     return this.updateContent(params);
   });

--- a/src/lib/layers/layers-text.component.ts
+++ b/src/lib/layers/layers-text.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, OnChanges, SimpleChanges, input } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FlipProp,
@@ -27,16 +27,16 @@ import { FaLayersComponent } from './layers.component';
   },
 })
 export class FaLayersTextComponent implements OnChanges {
-  @Input() content: string;
-  @Input() title?: string;
-  @Input() flip?: FlipProp;
-  @Input() size?: SizeProp;
-  @Input() pull?: PullProp;
-  @Input() border?: boolean;
-  @Input() inverse?: boolean;
-  @Input() rotate?: RotateProp | string;
-  @Input() fixedWidth?: boolean;
-  @Input() transform?: string | Transform;
+  readonly content = input.required<string>();
+  readonly title = input<string>();
+  readonly flip = input<FlipProp>();
+  readonly size = input<SizeProp>();
+  readonly pull = input<PullProp>();
+  readonly border = input<boolean>();
+  readonly inverse = input<boolean>();
+  readonly rotate = input<RotateProp | string>();
+  readonly fixedWidth = input<boolean>();
+  readonly transform = input<string | Transform>();
 
   @HostBinding('innerHTML') renderedHTML: SafeHtml;
 
@@ -61,16 +61,17 @@ export class FaLayersTextComponent implements OnChanges {
    */
   protected buildParams(): TextParams {
     const classOpts: FaProps = {
-      flip: this.flip,
-      border: this.border,
-      inverse: this.inverse,
-      size: this.size || null,
-      pull: this.pull || null,
-      rotate: this.rotate || null,
-      fixedWidth: this.fixedWidth,
+      flip: this.flip(),
+      border: this.border(),
+      inverse: this.inverse(),
+      size: this.size() || null,
+      pull: this.pull() || null,
+      rotate: this.rotate() || null,
+      fixedWidth: this.fixedWidth(),
     };
 
-    const parsedTransform = typeof this.transform === 'string' ? parse.transform(this.transform) : this.transform;
+    const transform = this.transform();
+    const parsedTransform = typeof transform === 'string' ? parse.transform(transform) : transform;
 
     const styles: Styles = {};
     if (classOpts.rotate != null && !isKnownRotateValue(classOpts.rotate)) {
@@ -80,13 +81,13 @@ export class FaLayersTextComponent implements OnChanges {
     return {
       transform: parsedTransform,
       classes: faClassList(classOpts),
-      title: this.title,
+      title: this.title(),
       styles,
     };
   }
 
   private updateContent(params: TextParams) {
     ensureCss(this.document, this.config);
-    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(text(this.content || '', params).html.join('\n'));
+    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(text(this.content() || '', params).html.join('\n'));
   }
 }

--- a/src/lib/layers/layers-text.component.ts
+++ b/src/lib/layers/layers-text.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, input, computed } from '@angular/core';
+import { Component, inject, input, computed, ChangeDetectionStrategy } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import {
   FlipProp,
@@ -26,6 +26,7 @@ import { FaLayersComponent } from './layers.component';
     class: 'ng-fa-layers-text',
     '[innerHTML]': 'renderedHTML()',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaLayersTextComponent {
   readonly content = input.required<string>();

--- a/src/lib/layers/layers-text.component.ts
+++ b/src/lib/layers/layers-text.component.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, OnChanges, SimpleChanges, input } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, inject, input, computed } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import {
   FlipProp,
   parse,
@@ -24,9 +24,10 @@ import { FaLayersComponent } from './layers.component';
   template: '',
   host: {
     class: 'ng-fa-layers-text',
+    '[innerHTML]': 'renderedHTML()',
   },
 })
-export class FaLayersTextComponent implements OnChanges {
+export class FaLayersTextComponent {
   readonly content = input.required<string>();
   readonly title = input<string>();
   readonly flip = input<FlipProp>();
@@ -38,7 +39,10 @@ export class FaLayersTextComponent implements OnChanges {
   readonly fixedWidth = input<boolean>();
   readonly transform = input<string | Transform>();
 
-  @HostBinding('innerHTML') renderedHTML: SafeHtml;
+  renderedHTML = computed(() => {
+    const params = this.buildParams();
+    return this.updateContent(params);
+  });
 
   private readonly document = inject(DOCUMENT);
   private readonly config = inject(FaConfig);
@@ -47,13 +51,6 @@ export class FaLayersTextComponent implements OnChanges {
 
   constructor() {
     faWarnIfParentNotExist(this.parent, 'FaLayersComponent', this.constructor.name);
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes) {
-      const params = this.buildParams();
-      this.updateContent(params);
-    }
   }
 
   /**
@@ -88,6 +85,6 @@ export class FaLayersTextComponent implements OnChanges {
 
   private updateContent(params: TextParams) {
     ensureCss(this.document, this.config);
-    this.renderedHTML = this.sanitizer.bypassSecurityTrustHtml(text(this.content() || '', params).html.join('\n'));
+    return this.sanitizer.bypassSecurityTrustHtml(text(this.content() || '', params).html.join('\n'));
   }
 }

--- a/src/lib/layers/layers-text.component.ts
+++ b/src/lib/layers/layers-text.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, HostBinding, inject, Input, OnChanges, Optional, SimpleChanges } from '@angular/core';
+import { Component, HostBinding, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   FlipProp,
@@ -40,13 +40,12 @@ export class FaLayersTextComponent implements OnChanges {
 
   @HostBinding('innerHTML') renderedHTML: SafeHtml;
 
-  private document = inject(DOCUMENT);
-  private config = inject(FaConfig);
+  private readonly document = inject(DOCUMENT);
+  private readonly config = inject(FaConfig);
+  private readonly parent = inject(FaLayersComponent, { optional: true });
+  private readonly sanitizer = inject(DomSanitizer);
 
-  constructor(
-    @Optional() private parent: FaLayersComponent,
-    private sanitizer: DomSanitizer,
-  ) {
+  constructor() {
     faWarnIfParentNotExist(this.parent, 'FaLayersComponent', this.constructor.name);
   }
 

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
@@ -13,15 +13,15 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faCoffee"></fa-icon>
+          <fa-icon [icon]="faUser()"></fa-icon>
+          <fa-icon [icon]="faCoffee()"></fa-icon>
           <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
         </fa-layers>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCoffee = faCoffee;
+      faUser = signal(faUser);
+      faCoffee = signal(faCoffee);
     }
 
     const fixture = initTest(HostComponent);
@@ -35,15 +35,15 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers size="2x">
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faCoffee"></fa-icon>
+          <fa-icon [icon]="faUser()"></fa-icon>
+          <fa-icon [icon]="faCoffee()"></fa-icon>
           <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
         </fa-layers>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCoffee = faCoffee;
+      faUser = signal(faUser);
+      faCoffee = signal(faCoffee);
     }
 
     const fixture = initTest(HostComponent);
@@ -57,7 +57,7 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: '<fa-layers [fixedWidth]="true"></fa-layers>',
     })
-    class HostComponent {}
+    class HostComponent { }
 
     const fixture = initTest(HostComponent);
     const config = TestBed.inject(FaConfig);
@@ -72,7 +72,7 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: '<fa-layers></fa-layers>',
     })
-    class HostComponent {}
+    class HostComponent { }
 
     const fixture = initTest(HostComponent);
     const config = TestBed.inject(FaConfig);
@@ -87,15 +87,15 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers [fixedWidth]="false">
-          <fa-icon [icon]="faUser"></fa-icon>
-          <fa-icon [icon]="faCoffee"></fa-icon>
+          <fa-icon [icon]="faUser()"></fa-icon>
+          <fa-icon [icon]="faCoffee()"></fa-icon>
           <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
         </fa-layers>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCoffee = faCoffee;
+      faUser = signal(faUser);
+      faCoffee = signal(faCoffee);
     }
 
     const fixture = initTest(HostComponent);
@@ -110,17 +110,17 @@ describe('FaLayersComponent', () => {
       selector: 'fa-host',
       standalone: false,
       template: `
-        <fa-layers class="custom-class" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [ngClass]="{ 'custom-class': true }" [fixedWidth]="fixedWidth" [size]="size"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" class="custom-class"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [class.custom-class]="true"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth" [size]="size" [ngClass]="{ 'custom-class': true }"></fa-layers>
+        <fa-layers class="custom-class" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
+        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
+        <fa-layers [ngClass]="{ 'custom-class': true }" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" class="custom-class"></fa-layers>
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [class.custom-class]="true"></fa-layers>
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [ngClass]="{ 'custom-class': true }"></fa-layers>
       `,
     })
     class HostComponent {
-      fixedWidth = true;
-      size: SizeProp = '4x';
+      fixedWidth = signal(true);
+      size = signal<SizeProp>('4x');
     }
 
     const fixture = initTest(HostComponent);
@@ -141,13 +141,13 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>
+          <fa-duotone-icon [icon]="faDummy()"></fa-duotone-icon>
           <fa-layers-text [content]="'Dummy'"></fa-layers-text>
         </fa-layers>
       `,
     })
     class HostComponent {
-      faDummy = faDummy;
+      faDummy = signal(faDummy);
     }
 
     const fixture = initTest(HostComponent);
@@ -162,14 +162,14 @@ describe('FaLayersComponent', () => {
       template: `
         <fa-layers>
           <ng-container>
-            <fa-icon [icon]="faUser"></fa-icon>
+            <fa-icon [icon]="faUser()"></fa-icon>
             <fa-layers-text [content]="'Dummy'"></fa-layers-text>
           </ng-container>
         </fa-layers>
       `,
     })
     class HostComponent {
-      faUser = faUser;
+      faUser = signal(faUser);
     }
 
     const fixture = initTest(HostComponent);

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -57,7 +57,7 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: '<fa-layers [fixedWidth]="true"></fa-layers>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     const config = TestBed.inject(FaConfig);
@@ -72,7 +72,7 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: '<fa-layers></fa-layers>',
     })
-    class HostComponent { }
+    class HostComponent {}
 
     const fixture = initTest(HostComponent);
     const config = TestBed.inject(FaConfig);

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -1,15 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import {
-  Component,
-  ElementRef,
-  inject,
-  OnChanges,
-  OnInit,
-  Renderer2,
-  SimpleChanges,
-  input,
-  computed,
-} from '@angular/core';
+import { Component, inject, OnInit, input, computed } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
 import { ensureCss } from '../shared/utils/css';
@@ -21,34 +11,30 @@ import { ensureCss } from '../shared/utils/css';
   selector: 'fa-layers',
   template: `<ng-content></ng-content>`,
   host: {
-    '[class.fa-fw]': 'faFw()',
+    '[class]': 'classes()',
   },
 })
-export class FaLayersComponent implements OnInit, OnChanges {
+export class FaLayersComponent implements OnInit {
   readonly size = input<SizeProp>();
   readonly fixedWidth = input<boolean>();
   readonly faFw = computed(() => {
     const fixedWidth = this.fixedWidth();
     return typeof fixedWidth === 'boolean' ? fixedWidth : this.config.fixedWidth;
   });
+  readonly classes = computed(() => {
+    const sizeValue = this.size();
+    const sizeClass = sizeValue ? { [`fa-${sizeValue}`]: true } : {};
+    return {
+      ...sizeClass,
+      'fa-fw': this.faFw(),
+      'fa-layers': true,
+    };
+  });
+
   private readonly document = inject(DOCUMENT);
-  private readonly renderer = inject(Renderer2);
-  private readonly elementRef = inject(ElementRef);
   private readonly config = inject(FaConfig);
 
   ngOnInit() {
-    this.renderer.addClass(this.elementRef.nativeElement, 'fa-layers');
     ensureCss(this.document, this.config);
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if ('size' in changes) {
-      if (changes.size.currentValue != null) {
-        this.renderer.addClass(this.elementRef.nativeElement, `fa-${changes.size.currentValue}`);
-      }
-      if (changes.size.previousValue != null) {
-        this.renderer.removeClass(this.elementRef.nativeElement, `fa-${changes.size.previousValue}`);
-      }
-    }
   }
 }

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -8,7 +8,7 @@ import {
   Renderer2,
   SimpleChanges,
   input,
-  computed
+  computed,
 } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
@@ -29,7 +29,7 @@ export class FaLayersComponent implements OnInit, OnChanges {
   readonly fixedWidth = input<boolean>();
   readonly faFw = computed(() => {
     const fixedWidth = this.fixedWidth();
-    return typeof fixedWidth === 'boolean' ? fixedWidth : this.config.fixedWidth
+    return typeof fixedWidth === 'boolean' ? fixedWidth : this.config.fixedWidth;
   });
   private readonly document = inject(DOCUMENT);
   private readonly renderer = inject(Renderer2);

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -26,13 +26,10 @@ export class FaLayersComponent implements OnInit, OnChanges {
 
   @Input() @HostBinding('class.fa-fw') fixedWidth?: boolean;
 
-  private document = inject(DOCUMENT);
-
-  constructor(
-    private renderer: Renderer2,
-    private elementRef: ElementRef,
-    private config: FaConfig,
-  ) {}
+  private readonly document = inject(DOCUMENT);
+  private readonly renderer = inject(Renderer2);
+  private readonly elementRef = inject(ElementRef);
+  private readonly config = inject(FaConfig);
 
   ngOnInit() {
     this.renderer.addClass(this.elementRef.nativeElement, 'fa-layers');

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -2,13 +2,13 @@ import { DOCUMENT } from '@angular/common';
 import {
   Component,
   ElementRef,
-  HostBinding,
   inject,
-  Input,
   OnChanges,
   OnInit,
   Renderer2,
   SimpleChanges,
+  input,
+  computed
 } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
@@ -20,12 +20,17 @@ import { ensureCss } from '../shared/utils/css';
 @Component({
   selector: 'fa-layers',
   template: `<ng-content></ng-content>`,
+  host: {
+    '[class.fa-fw]': 'faFw()',
+  },
 })
 export class FaLayersComponent implements OnInit, OnChanges {
-  @Input() size?: SizeProp;
-
-  @Input() @HostBinding('class.fa-fw') fixedWidth?: boolean;
-
+  readonly size = input<SizeProp>();
+  readonly fixedWidth = input<boolean>();
+  readonly faFw = computed(() => {
+    const fixedWidth = this.fixedWidth();
+    return typeof fixedWidth === 'boolean' ? fixedWidth : this.config.fixedWidth
+  });
   private readonly document = inject(DOCUMENT);
   private readonly renderer = inject(Renderer2);
   private readonly elementRef = inject(ElementRef);
@@ -34,7 +39,6 @@ export class FaLayersComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.renderer.addClass(this.elementRef.nativeElement, 'fa-layers');
     ensureCss(this.document, this.config);
-    this.fixedWidth = typeof this.fixedWidth === 'boolean' ? this.fixedWidth : this.config.fixedWidth;
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, inject, OnInit, input, computed } from '@angular/core';
+import { Component, inject, OnInit, input, computed, ChangeDetectionStrategy } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaConfig } from '../config';
 import { ensureCss } from '../shared/utils/css';
@@ -13,6 +13,7 @@ import { ensureCss } from '../shared/utils/css';
   host: {
     '[class]': 'classes()',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaLayersComponent implements OnInit {
   readonly size = input<SizeProp>();

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -58,7 +58,7 @@ describe('FaStackItemSizeDirective', () => {
     expect(() => initTest(HostComponent)).toThrow(
       new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
-        'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
+          'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
       ),
     );
   });

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -55,7 +55,9 @@ describe('FaStackItemSizeDirective', () => {
       faCircle = faCircle;
     }
 
-    expect(() => initTest(HostComponent)).toThrow(
+    const fixture = initTest(HostComponent);
+
+    expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
           'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Type } from '@angular/core';
+import { Component, ElementRef, signal, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
 import { FaIconComponent } from '../icon/icon.component';
@@ -23,14 +23,14 @@ describe('FaStackItemSizeDirective', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
         </fa-stack>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCircle = faCircle;
+      faUser = signal(faUser);
+      faCircle = signal(faCircle);
     }
 
     const fixture = initTest(HostComponent);
@@ -45,14 +45,14 @@ describe('FaStackItemSizeDirective', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser" [inverse]="true" size="1x" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
+          <fa-icon [icon]="faUser()" [inverse]="true" size="1x" stackItemSize="1x"></fa-icon>
         </fa-stack>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCircle = faCircle;
+      faUser = signal(faUser);
+      faCircle = signal(faCircle);
     }
 
     const fixture = initTest(HostComponent);
@@ -60,7 +60,7 @@ describe('FaStackItemSizeDirective', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
-          'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
+        'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
       ),
     );
   });

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -60,7 +60,7 @@ describe('FaStackItemSizeDirective', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
-        'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
+          'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
       ),
     );
   });

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -55,11 +55,10 @@ describe('FaStackItemSizeDirective', () => {
       faCircle = faCircle;
     }
 
-    const fixture = initTest(HostComponent);
-    expect(() => fixture.detectChanges()).toThrow(
+    expect(() => initTest(HostComponent)).toThrow(
       new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
-          'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
+        'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
       ),
     );
   });

--- a/src/lib/stack/stack-item-size.directive.ts
+++ b/src/lib/stack/stack-item-size.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, OnChanges, SimpleChanges, input } from '@angular/core';
+import { Directive, effect, input } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaStackComponent } from './stack.component';
 
@@ -6,7 +6,7 @@ import { FaStackComponent } from './stack.component';
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: 'fa-icon[stackItemSize],fa-duotone-icon[stackItemSize]',
 })
-export class FaStackItemSizeDirective implements OnChanges {
+export class FaStackItemSizeDirective {
   /**
    * Specify whether icon inside {@link FaStackComponent} should be rendered in
    * regular size (1x) or as a larger icon (2x).
@@ -18,12 +18,13 @@ export class FaStackItemSizeDirective implements OnChanges {
    */
   readonly size = input<SizeProp>();
 
-  ngOnChanges(changes: SimpleChanges) {
-    if ('size' in changes) {
+  _effect = effect(() => {
+    const size = this.size();
+    if (size) {
       throw new Error(
         'fa-icon is not allowed to customize size when used inside fa-stack. ' +
           'Set size on the enclosing fa-stack instead: <fa-stack size="4x">...</fa-stack>.',
       );
     }
-  }
+  });
 }

--- a/src/lib/stack/stack-item-size.directive.ts
+++ b/src/lib/stack/stack-item-size.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Directive, OnChanges, SimpleChanges, input } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FaStackComponent } from './stack.component';
 
@@ -11,12 +11,12 @@ export class FaStackItemSizeDirective implements OnChanges {
    * Specify whether icon inside {@link FaStackComponent} should be rendered in
    * regular size (1x) or as a larger icon (2x).
    */
-  @Input() stackItemSize: '1x' | '2x' = '1x';
+  readonly stackItemSize = input<'1x' | '2x'>('1x');
 
   /**
    * @internal
    */
-  @Input() size?: SizeProp;
+  readonly size = input<SizeProp>();
 
   ngOnChanges(changes: SimpleChanges) {
     if ('size' in changes) {

--- a/src/lib/stack/stack.component.spec.ts
+++ b/src/lib/stack/stack.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
 import { faDummy, initTest, queryByCss } from '../../testing/helpers';
-import { FaStackComponent } from './stack.component';
 
 describe('FaStackComponent', () => {
   it('should render stack icon', () => {

--- a/src/lib/stack/stack.component.spec.ts
+++ b/src/lib/stack/stack.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { faCircle, faUser } from '@fortawesome/free-solid-svg-icons';
 import { faDummy, initTest, queryByCss } from '../../testing/helpers';
 
@@ -9,14 +9,14 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
         </fa-stack>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCircle = faCircle;
+      faUser = signal(faUser);
+      faCircle = signal(faCircle);
     }
 
     const fixture = initTest(HostComponent);
@@ -30,14 +30,14 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-          <fa-duotone-icon [icon]="dummyDuotoneIcon" [inverse]="true" stackItemSize="1x"></fa-duotone-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
+          <fa-duotone-icon [icon]="dummyDuotoneIcon()" [inverse]="true" stackItemSize="1x"></fa-duotone-icon>
         </fa-stack>
       `,
     })
     class HostComponent {
-      dummyDuotoneIcon = faDummy;
-      faCircle = faCircle;
+      dummyDuotoneIcon = signal(faDummy);
+      faCircle = signal(faCircle);
     }
 
     const fixture = initTest(HostComponent);
@@ -51,14 +51,14 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack size="2x">
-          <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
         </fa-stack>
       `,
     })
     class HostComponent {
-      faUser = faUser;
-      faCircle = faCircle;
+      faUser = signal(faUser);
+      faCircle = signal(faCircle);
     }
 
     const fixture = initTest(HostComponent);

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, inject, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, inject, OnChanges, OnInit, Renderer2, SimpleChanges, input } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
@@ -12,7 +12,7 @@ export class FaStackComponent implements OnInit, OnChanges {
    * You'll need to set size using custom CSS to align stacked icon with a
    * simple one. E.g. `fa-stack { font-size: 0.5em; }`.
    */
-  @Input() size?: SizeProp;
+  readonly size = input<SizeProp>();
 
   private readonly renderer = inject(Renderer2);
   private readonly elementRef = inject(ElementRef);

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, inject, Input, OnChanges, OnInit, Renderer2, SimpleChanges } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
@@ -14,10 +14,8 @@ export class FaStackComponent implements OnInit, OnChanges {
    */
   @Input() size?: SizeProp;
 
-  constructor(
-    private renderer: Renderer2,
-    private elementRef: ElementRef,
-  ) {}
+  private readonly renderer = inject(Renderer2);
+  private readonly elementRef = inject(ElementRef);
 
   ngOnInit() {
     this.renderer.addClass(this.elementRef.nativeElement, 'fa-stack');

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,11 +1,14 @@
-import { Component, ElementRef, inject, OnChanges, OnInit, Renderer2, SimpleChanges, input } from '@angular/core';
+import { Component, input, computed } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
   selector: 'fa-stack',
   template: `<ng-content></ng-content>`,
+  host: {
+    '[class]': 'classes()',
+  },
 })
-export class FaStackComponent implements OnInit, OnChanges {
+export class FaStackComponent {
   /**
    * Size of the stacked icon.
    * Note that stacked icon is by default 2 times bigger, than non-stacked icon.
@@ -14,21 +17,12 @@ export class FaStackComponent implements OnInit, OnChanges {
    */
   readonly size = input<SizeProp>();
 
-  private readonly renderer = inject(Renderer2);
-  private readonly elementRef = inject(ElementRef);
-
-  ngOnInit() {
-    this.renderer.addClass(this.elementRef.nativeElement, 'fa-stack');
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if ('size' in changes) {
-      if (changes.size.currentValue != null) {
-        this.renderer.addClass(this.elementRef.nativeElement, `fa-${changes.size.currentValue}`);
-      }
-      if (changes.size.previousValue != null) {
-        this.renderer.removeClass(this.elementRef.nativeElement, `fa-${changes.size.previousValue}`);
-      }
-    }
-  }
+  readonly classes = computed(() => {
+    const sizeValue = this.size();
+    const sizeClass = sizeValue ? { [`fa-${sizeValue}`]: true } : {};
+    return {
+      ...sizeClass,
+      'fa-stack': true,
+    };
+  });
 }

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, computed } from '@angular/core';
+import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
 import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
@@ -7,6 +7,7 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
   host: {
     '[class]': 'classes()',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaStackComponent {
   /**


### PR DESCRIPTION
# Convert to use signal `input` and `output`
This update will make the components use the latest signal inputs, outputs, computed, effect.
Library code will be following the reactive style.

Changes include
- Convert `@Input` to `input` signal
- Convert `@Ouput` to `output` signal
- Use `setInput` on component instance
- Replaced `ngOnChanges`, with `computed` / `efffect`
- Used `ChangeDetectionStrategy.OnPush` strategy
- Updates affected tests to use signal
- Update tests with signal -✅