### PR TITLE
chore(icon): remove required constraint on icon input to support dyna…

### DIFF
--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -37,7 +37,7 @@ import { IconDefinition, IconProp } from '../types';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FaIconComponent {
-  readonly icon = model.required<IconProp>();
+  readonly icon = model<IconProp>();
 
   /**
    * Specify a title for the icon.
@@ -74,13 +74,13 @@ export class FaIconComponent {
   readonly a11yRole = model<string>();
 
   readonly renderedIconHTML = computed(() => {
-    const iconValue = this.icon();
-    if (iconValue == null && this.config.fallbackIcon == null) {
+    const iconValue = this.icon() ?? this.config.fallbackIcon;
+    if (!iconValue) {
       faWarnIfIconSpecMissing();
       return '';
     }
 
-    const iconDefinition = this.findIconDefinition(iconValue ?? this.config.fallbackIcon);
+    const iconDefinition = this.findIconDefinition(iconValue);
     if (!iconDefinition) {
       return '';
     }


### PR DESCRIPTION
In version 2.0.1, the `icon` input on `fa-icon` was marked as required using Angular's `model.required()`.

This PR makes the `icon` input optional again, to support use cases where the icon is assigned dynamically via a custom directive or service at runtime. These patterns are useful for maintaining clean templates and centralizing icon configuration.

Since the library already provides a runtime check (`faWarnIfIconSpecMissing()`), compile-time enforcement may be overly restrictive for some scenarios.

This change restores flexibility while maintaining runtime safety.

Let me know if you'd prefer a different approach or additional test coverage. Happy to adjust as needed!

Closes #475 
