### PR TITLE
Convert most FontAwesome elements to self-closing tags

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -10,7 +10,8 @@ Thanks for taking the time to consider contributing to the project. You will fin
 ## Setting up the local environment
 
 1. `git clone https://github.com/FortAwesome/angular-fontawesome`
-1. `corepack enable` - to get the global `yarn` command 
+1. `cd angular-fontawesome`
+1. `corepack enable` - to get the global `yarn` command
 1. `yarn` - install dependencies
 1. `yarn build:watch` (in terminal 1) - build the library and keep watching for changes
 1. `yarn start` (in terminal 2) - start sample application using library distribution from the previous step

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To get up and running using Font Awesome with Angular follow the below steps:
 `src/app/app.component.html`:
 
     ```html
-    <fa-icon [icon]="faCoffee"></fa-icon>
+    <fa-icon [icon]="faCoffee" />
     ```
 
 ## Documentation

--- a/docs/guide/storybook.md
+++ b/docs/guide/storybook.md
@@ -36,12 +36,12 @@ export default {
 export const iconStory = () => ({
   template: `
       <button>
-        <fa-icon [icon]="homeIcon"></fa-icon>
+        <fa-icon [icon]="homeIcon" />
         Go Home
       </button>
       
       <button>
-        <fa-icon [icon]="closeIcon"></fa-icon>
+        <fa-icon [icon]="closeIcon" />
         Close
       </button>
   `,

--- a/docs/guide/styling-icon-internals.md
+++ b/docs/guide/styling-icon-internals.md
@@ -19,7 +19,7 @@ fa-icon.fancy svg path {
 
 ```angular2html
 <!-- app.component.html -->
-<fa-icon icon="user" class="fancy"></fa-icon>
+<fa-icon icon="user" class="fancy" />
 ```
 
 ## Use `::ng-deep` pseudo-class selector
@@ -31,7 +31,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  template: '<fa-icon icon="user" class="fancy"></fa-icon>',
+  template: '<fa-icon icon="user" class="fancy" />',
   styles: [`
     fa-icon.fancy ::ng-deep svg path {
       fill: #ffffff;

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -11,11 +11,11 @@ import { Component } from '@angular/core';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
-    selector: 'app-explicit-reference',
-    template: '<fa-icon [icon]="faUser" />',
+  selector: 'app-explicit-reference',
+  template: '<fa-icon [icon]="faUser" />',
 })
 export class ExplicitReferenceComponent {
-    faUser = faUser;
+  faUser = faUser;
 }
 ```
 
@@ -25,26 +25,27 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ExplicitReferenceComponent } from './explicit-reference.component';
 
 describe('ExplicitReferenceComponent', () => {
-    let component: ExplicitReferenceComponent;
-    let fixture: ComponentFixture<ExplicitReferenceComponent>;
+  let component: ExplicitReferenceComponent;
+  let fixture: ComponentFixture<ExplicitReferenceComponent>;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [FontAwesomeModule], // <--
-            declarations: [ExplicitReferenceComponent],
-        });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FontAwesomeModule], // <--
+      declarations: [ExplicitReferenceComponent],
     });
+  });
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(ExplicitReferenceComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExplicitReferenceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });
+
 ```
 
 ## Test components using [icon library](../usage/icon-library.md)
@@ -67,13 +68,13 @@ import { FaIconLibrary, FontAwesomeModule } from '@fortawesome/angular-fontaweso
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 @NgModule({
-    imports: [FontAwesomeModule],
-    exports: [FontAwesomeModule],
+  imports: [FontAwesomeModule],
+  exports: [FontAwesomeModule],
 })
 class FontAwesomeIconsModule {
-    constructor(library: FaIconLibrary) {
-        library.addIcons(faUser);
-    }
+  constructor(library: FaIconLibrary) {
+    library.addIcons(faUser);
+  }
 }
 ```
 
@@ -83,8 +84,8 @@ And here is how it should be used in test code:
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-regular-icon-library',
-    template: '<fa-icon icon="user" />',
+  selector: 'app-regular-icon-library',
+  template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -94,29 +95,29 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-    let component: IconLibraryComponent;
-    let fixture: ComponentFixture<IconLibraryComponent>;
+  let component: IconLibraryComponent;
+  let fixture: ComponentFixture<IconLibraryComponent>;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [FontAwesomeIconsModule], // <--
-            declarations: [IconLibraryComponent],
-        });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FontAwesomeIconsModule], // <--
+      declarations: [IconLibraryComponent],
     });
+  });
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(IconLibraryComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IconLibraryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });
 ```
 
-_This approach was [initially suggested by 1FpGLLjZSZMx6k on StackOverflow](https://stackoverflow.com/a/58380192/1377864)._
+*This approach was [initially suggested by 1FpGLLjZSZMx6k on StackOverflow](https://stackoverflow.com/a/58380192/1377864).*
 
 ### Configure regular `FaIconLibrary`
 
@@ -126,8 +127,8 @@ To use this approach you'll need to add `FontAwesomeModule` to the `imports` of 
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-regular-icon-library',
-    template: '<fa-icon icon="user" />',
+  selector: 'app-regular-icon-library',
+  template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -139,29 +140,29 @@ import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-    let component: IconLibraryComponent;
-    let fixture: ComponentFixture<IconLibraryComponent>;
+  let component: IconLibraryComponent;
+  let fixture: ComponentFixture<IconLibraryComponent>;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [FontAwesomeModule], // <--
-            declarations: [IconLibraryComponent],
-        });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FontAwesomeModule], // <--
+      declarations: [IconLibraryComponent],
     });
+  });
 
-    beforeEach(() => {
-        // Use TestBed.get(FaIconLibrary) if you use Angular < 9.
-        const library = TestBed.inject(FaIconLibrary); // <--
-        library.addIcons(faUser); // <--
+  beforeEach(() => {
+    // Use TestBed.get(FaIconLibrary) if you use Angular < 9.
+    const library = TestBed.inject(FaIconLibrary); // <--
+    library.addIcons(faUser); // <--
 
-        fixture = TestBed.createComponent(IconLibraryComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+    fixture = TestBed.createComponent(IconLibraryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });
 ```
 
@@ -173,8 +174,8 @@ describe('IconLibraryComponent', () => {
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-regular-icon-library',
-    template: '<fa-icon icon="user" />',
+  selector: 'app-regular-icon-library',
+  template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -185,24 +186,24 @@ import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testi
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-    let component: IconLibraryComponent;
-    let fixture: ComponentFixture<IconLibraryComponent>;
+  let component: IconLibraryComponent;
+  let fixture: ComponentFixture<IconLibraryComponent>;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [FontAwesomeTestingModule], // <--
-            declarations: [IconLibraryComponent],
-        });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FontAwesomeTestingModule], // <--
+      declarations: [IconLibraryComponent],
     });
+  });
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(IconLibraryComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IconLibraryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });
 ```

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -11,11 +11,11 @@ import { Component } from '@angular/core';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
-  selector: 'app-explicit-reference',
-  template: '<fa-icon [icon]="faUser"></fa-icon>',
+    selector: 'app-explicit-reference',
+    template: '<fa-icon [icon]="faUser" />',
 })
 export class ExplicitReferenceComponent {
-  faUser = faUser;
+    faUser = faUser;
 }
 ```
 
@@ -25,27 +25,26 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ExplicitReferenceComponent } from './explicit-reference.component';
 
 describe('ExplicitReferenceComponent', () => {
-  let component: ExplicitReferenceComponent;
-  let fixture: ComponentFixture<ExplicitReferenceComponent>;
+    let component: ExplicitReferenceComponent;
+    let fixture: ComponentFixture<ExplicitReferenceComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [FontAwesomeModule], // <--
-      declarations: [ExplicitReferenceComponent],
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeModule], // <--
+            declarations: [ExplicitReferenceComponent],
+        });
     });
-  });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ExplicitReferenceComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ExplicitReferenceComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });
-
 ```
 
 ## Test components using [icon library](../usage/icon-library.md)
@@ -68,13 +67,13 @@ import { FaIconLibrary, FontAwesomeModule } from '@fortawesome/angular-fontaweso
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 
 @NgModule({
-  imports: [FontAwesomeModule],
-  exports: [FontAwesomeModule],
+    imports: [FontAwesomeModule],
+    exports: [FontAwesomeModule],
 })
 class FontAwesomeIconsModule {
-  constructor(library: FaIconLibrary) {
-    library.addIcons(faUser);
-  }
+    constructor(library: FaIconLibrary) {
+        library.addIcons(faUser);
+    }
 }
 ```
 
@@ -84,8 +83,8 @@ And here is how it should be used in test code:
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-regular-icon-library',
-  template: '<fa-icon icon="user"></fa-icon>',
+    selector: 'app-regular-icon-library',
+    template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -95,29 +94,29 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-  let component: IconLibraryComponent;
-  let fixture: ComponentFixture<IconLibraryComponent>;
+    let component: IconLibraryComponent;
+    let fixture: ComponentFixture<IconLibraryComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [FontAwesomeIconsModule], // <--
-      declarations: [IconLibraryComponent],
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeIconsModule], // <--
+            declarations: [IconLibraryComponent],
+        });
     });
-  });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(IconLibraryComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(IconLibraryComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });
 ```
 
-*This approach was [initially suggested by 1FpGLLjZSZMx6k on StackOverflow](https://stackoverflow.com/a/58380192/1377864).*
+_This approach was [initially suggested by 1FpGLLjZSZMx6k on StackOverflow](https://stackoverflow.com/a/58380192/1377864)._
 
 ### Configure regular `FaIconLibrary`
 
@@ -127,8 +126,8 @@ To use this approach you'll need to add `FontAwesomeModule` to the `imports` of 
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-regular-icon-library',
-  template: '<fa-icon icon="user"></fa-icon>',
+    selector: 'app-regular-icon-library',
+    template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -140,29 +139,29 @@ import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-  let component: IconLibraryComponent;
-  let fixture: ComponentFixture<IconLibraryComponent>;
+    let component: IconLibraryComponent;
+    let fixture: ComponentFixture<IconLibraryComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [FontAwesomeModule], // <--
-      declarations: [IconLibraryComponent],
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeModule], // <--
+            declarations: [IconLibraryComponent],
+        });
     });
-  });
 
-  beforeEach(() => {
-    // Use TestBed.get(FaIconLibrary) if you use Angular < 9.
-    const library = TestBed.inject(FaIconLibrary); // <--
-    library.addIcons(faUser); // <--
+    beforeEach(() => {
+        // Use TestBed.get(FaIconLibrary) if you use Angular < 9.
+        const library = TestBed.inject(FaIconLibrary); // <--
+        library.addIcons(faUser); // <--
 
-    fixture = TestBed.createComponent(IconLibraryComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+        fixture = TestBed.createComponent(IconLibraryComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });
 ```
 
@@ -174,8 +173,8 @@ describe('IconLibraryComponent', () => {
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-regular-icon-library',
-  template: '<fa-icon icon="user"></fa-icon>',
+    selector: 'app-regular-icon-library',
+    template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}
 ```
@@ -186,24 +185,24 @@ import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testi
 import { IconLibraryComponent } from './icon-library.component';
 
 describe('IconLibraryComponent', () => {
-  let component: IconLibraryComponent;
-  let fixture: ComponentFixture<IconLibraryComponent>;
+    let component: IconLibraryComponent;
+    let fixture: ComponentFixture<IconLibraryComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [FontAwesomeTestingModule], // <--
-      declarations: [IconLibraryComponent],
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [FontAwesomeTestingModule], // <--
+            declarations: [IconLibraryComponent],
+        });
     });
-  });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(IconLibraryComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(IconLibraryComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });
 ```

--- a/docs/upgrading/1.0.0-2.0.0.md
+++ b/docs/upgrading/1.0.0-2.0.0.md
@@ -33,7 +33,7 @@ class HostComponent {
 ```diff
 @Component({
   selector: 'fa-host',
-  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()" />'
 })
 class HostComponent {
   readonly faUser = faUser;

--- a/docs/usage/explicit-reference.md
+++ b/docs/usage/explicit-reference.md
@@ -8,7 +8,7 @@ While this approach is more verbose than the [icon library](./icon-library.md) a
 
 ```html
 <div style="text-align:center">
-  <fa-icon [icon]="faCoffee"></fa-icon>
+  <fa-icon [icon]="faCoffee" />
 </div>
 ```
 

--- a/docs/usage/features.md
+++ b/docs/usage/features.md
@@ -7,60 +7,59 @@ The following features are available as part of Font Awesome. Note that the synt
 ### Size
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/sizing-icons)
 ```html
-<fa-icon [icon]="['fas', 'coffee']" size="xs"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" size="lg"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" size="6x"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" size="xs" />
+<fa-icon [icon]="['fas', 'coffee']" size="lg" />
+<fa-icon [icon]="['fas', 'coffee']" size="6x" />
 ```
 
 ### Fixed Width
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/fixed-width-icons):
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" [fixedWidth]="true"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" [fixedWidth]="true" />
 ```
 
 ### Rotate
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/rotating-icons):
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" [rotate]="90"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" [rotate]="180"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" [rotate]="270"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" [rotate]="90" />
+<fa-icon [icon]="['fas', 'coffee']" [rotate]="180" />
+<fa-icon [icon]="['fas', 'coffee']" [rotate]="270" />
 <!-- Or any value supported by the rotate() transform can be specified. -->
-<fa-icon [icon]="['fas', 'coffee']" rotate="45deg"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" rotate="45deg" />
 ```
 
 ### Flip
 * horizontally, vertically, or both
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" flip="horizontal"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" flip="vertical"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" flip="both"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" flip="horizontal" />
+<fa-icon [icon]="['fas', 'coffee']" flip="vertical" />
+<fa-icon [icon]="['fas', 'coffee']" flip="both" />
 ```
 
 ### Animations
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/animating-icons)
 
 ```html
-<fa-icon [icon]="['fas', 'cog']" animation="spin"></fa-icon>
-<fa-icon [icon]="['fas', 'heart']" animation="beat"></fa-icon>
-<fa-icon [icon]="['fas', 'bell']" animation="shake"></fa-icon>
+<fa-icon [icon]="['fas', 'cog']" animation="spin" />
+<fa-icon [icon]="['fas', 'heart']" animation="beat" />
+<fa-icon [icon]="['fas', 'bell']" animation="shake" />
 ```
 
 ### Border
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/bordered-pulled-icons):
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" [border]="true"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" [border]="true" />
 ```
 
 ### Pull
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/bordered-pulled-icons):
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" pull="left"></fa-icon>
-<fa-icon [icon]="['fas', 'coffee']" pull="right"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" pull="left" /> <fa-icon [icon]="['fas', 'coffee']" pull="right" />
 ```
 
 ### Custom styles
@@ -69,12 +68,12 @@ Simple styles can be applied using usual [class and style bindings](https://angu
 
 ```css
 .red-icon {
-  color: red;
+    color: red;
 }
 ```
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" class="red-icon" [style]="{display: 'inline-block', padding: '5px'}"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" class="red-icon" [style]="{display: 'inline-block', padding: '5px'}" />
 ```
 
 For more advanced styling, see [Styling icon internals](../guide/styling-icon-internals.md).
@@ -86,7 +85,7 @@ For more advanced styling, see [Styling icon internals](../guide/styling-icon-in
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#basic-use):
 
 ```html
-<fa-duotone-icon [icon]="['fad', 'coffee']"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" />
 ```
 
 ### Swap layers opacity
@@ -94,7 +93,7 @@ For more advanced styling, see [Styling icon internals](../guide/styling-icon-in
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#swapping-layers):
 
 ```html
-<fa-duotone-icon [icon]="['fad', 'coffee']" swapOpacity="true"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" swapOpacity="true" />
 ```
 
 ### Customize layers opacity
@@ -102,8 +101,8 @@ For more advanced styling, see [Styling icon internals](../guide/styling-icon-in
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity):
 
 ```html
-<fa-duotone-icon [icon]="['fad', 'coffee']" primaryOpacity="0.9"></fa-duotone-icon>
-<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryOpacity="0.1"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" primaryOpacity="0.9" />
+<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryOpacity="0.1" />
 ```
 
 ### Customize layers color
@@ -111,8 +110,8 @@ For more advanced styling, see [Styling icon internals](../guide/styling-icon-in
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#coloring):
 
 ```html
-<fa-duotone-icon [icon]="['fad', 'coffee']" primaryColor="red"></fa-duotone-icon>
-<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryColor="blue"></fa-duotone-icon>
+<fa-duotone-icon [icon]="['fad', 'coffee']" primaryColor="red" />
+<fa-duotone-icon [icon]="['fad', 'coffee']" secondaryColor="blue" />
 ```
 
 ## Advanced Usage
@@ -120,26 +119,30 @@ For more advanced styling, see [Styling icon internals](../guide/styling-icon-in
 ### Mask
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/masking)
 ```html
-<fa-icon [icon]="['fas', 'coffee']" [mask]="['fas', 'square']"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" [mask]="['fas', 'square']" />
 ```
 
 ### Transform
 [FontAwesome Spec](https://fontawesome.com/how-to-use/on-the-web/styling/power-transforms)
 
 ```html
-<fa-icon [icon]="['fas', 'coffee']" transform="shrink-9 right-4"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" transform="shrink-9 right-4" />
 ```
 
 ### Stateful Animations
 ```html
-<fa-icon [icon]="['fas', 'sync']" [animation]="isSyncAnimated ? 'spin' : undefined" (click)="isSyncAnimated=!isSyncAnimated"></fa-icon>
+<fa-icon
+    [icon]="['fas', 'sync']"
+    [animation]="isSyncAnimated ? 'spin' : undefined"
+    (click)="isSyncAnimated=!isSyncAnimated"
+/>
 ```
 
 ### Transform within binding:
 
 ```html
-<fa-icon [icon]="['fas', 'magic']" transform="rotate-{{magicLevel}}"></fa-icon>
-<input type='range' [value]="magicLevel" (input)="magicLevel=$event.target.value"/>
+<fa-icon [icon]="['fas', 'magic']" transform="rotate-{{magicLevel}}" />
+<input type="range" [value]="magicLevel" (input)="magicLevel=$event.target.value" />
 ```
 (Slide input range to "turn up the magic")
 
@@ -151,8 +154,8 @@ Each `<fa-icon>` declared inside an `<fa-stack>` element **must** include the `s
 
 ```html
 <fa-stack>
-  <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-  <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x"></fa-icon>
+    <fa-icon [icon]="faCircle" stackItemSize="2x" />
+    <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x" />
 </fa-stack>
 ```
 
@@ -163,8 +166,8 @@ When using standalone components, make sure to also add `FaStackItemSizeDirectiv
 
 ```html
 <fa-layers [fixedWidth]="true">
-  <fa-icon [icon]="['fas', 'square']"></fa-icon>
-  <fa-icon [inverse]="true" [icon]="['fas', 'spinner']" transform="shrink-6"></fa-icon>
+    <fa-icon [icon]="['fas', 'square']" />
+    <fa-icon [inverse]="true" [icon]="['fas', 'spinner']" transform="shrink-6" />
 </fa-layers>
 ```
 
@@ -173,8 +176,8 @@ When using standalone components, make sure to also add `FaStackItemSizeDirectiv
 
 ```html
 <fa-layers [fixedWidth]="true">
-  <fa-icon [icon]="['fas', 'square']"></fa-icon>
-  <fa-layers-text content="Yo" style="color: white;" transform="shrink-4"></fa-layers-text>
+    <fa-icon [icon]="['fas', 'square']" />
+    <fa-layers-text content="Yo" style="color: white;" transform="shrink-4" />
 </fa-layers>
 ```
 
@@ -183,8 +186,8 @@ When using standalone components, make sure to also add `FaStackItemSizeDirectiv
 
 ```html
 <fa-layers [fixedWidth]="true">
-  <fa-icon [icon]="['fas', 'envelope']"></fa-icon>
-  <fa-layers-counter content="99+"></fa-layers-counter>
+    <fa-icon [icon]="['fas', 'envelope']" />
+    <fa-layers-counter content="99+" />
 </fa-layers>
 ```
 
@@ -220,7 +223,7 @@ To update `FaIconComponent` programmatically:
 ```ts
 @Component({
   selector: 'fa-host',
-  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()" />',
 })
 class HostComponent {
   readonly faUser = faUser;
@@ -259,7 +262,7 @@ To update `FaIconComponent` programmatically:
 ```ts
 @Component({
   selector: 'fa-host',
-  template: '<fa-icon [icon]="faUser" (click)="spinIcon()"></fa-icon>'
+  template: '<fa-icon [icon]="faUser" (click)="spinIcon()" />'
 })
 class HostComponent {
   faUser = faUser;

--- a/docs/usage/icon-library.md
+++ b/docs/usage/icon-library.md
@@ -8,9 +8,9 @@ Icons should be registered only once in the `AppComponent`'s constructor using `
 
 ```html
 <!-- simple name only that assumes the default prefix -->
-<fa-icon icon="coffee"></fa-icon>
+<fa-icon icon="coffee" />
 <!-- ['fas', 'coffee'] is an array that indicates the [prefix, iconName] -->
-<fa-icon [icon]="['fas', 'coffee']"></fa-icon>
+<fa-icon [icon]="['fas', 'coffee']" />
 ```
 
 `src/app/app.component.ts`

--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -132,6 +132,5 @@ export class AppModule {
 ```
 
 ```html
-<fa-icon [icon]="['fas', 'star']"></fa-icon>
-<fa-icon [icon]="['far', 'star']"></fa-icon>
+<fa-icon [icon]="['fas', 'star']" /> <fa-icon [icon]="['far', 'star']" />
 ```

--- a/docs/usage/using-other-styles.md
+++ b/docs/usage/using-other-styles.md
@@ -132,5 +132,6 @@ export class AppModule {
 ```
 
 ```html
-<fa-icon [icon]="['fas', 'star']" /> <fa-icon [icon]="['far', 'star']" />
+<fa-icon [icon]="['fas', 'star']" />
+<fa-icon [icon]="['far', 'star']" />
 ```

--- a/projects/demo/src/app/alternate-prefix.component.html
+++ b/projects/demo/src/app/alternate-prefix.component.html
@@ -4,7 +4,7 @@
     The default icon prefix is usually <code>fas</code> but can be adjusted by injecting the <code>FaConfig</code> and
     changing the <code>defaultPrefix</code> property.
   </p>
-  <fa-icon icon="user" size="lg" [fixedWidth]="true"></fa-icon>
-  <fa-icon icon="hand-paper" size="lg" [fixedWidth]="true"></fa-icon>
-  <fa-icon icon="bell-slash" size="lg" [fixedWidth]="true"></fa-icon>
+  <fa-icon icon="user" size="lg" [fixedWidth]="true" />
+  <fa-icon icon="hand-paper" size="lg" [fixedWidth]="true" />
+  <fa-icon icon="bell-slash" size="lg" [fixedWidth]="true" />
 </span>

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -1,23 +1,23 @@
 <h1>Font Awesome examples</h1>
 
 <h3>Icon as Object (with title attribute—inspect the DOM to see it)</h3>
-<fa-icon [icon]="faCoffee" title="Coffee: Best Drink Ever"></fa-icon>
+<fa-icon [icon]="faCoffee" title="Coffee: Best Drink Ever" />
 
 <h3>Icon looked up in library by name</h3>
 <p>
   Possible after adding the <code>faUser</code> icon from the <code>free-solid-svg-icons</code> package to the library.
 </p>
 <p>The default prefix of <code>fas</code> is assumed. Also, add a border.</p>
-<fa-icon icon="user" [border]="true" a11yRole="presentation"></fa-icon>
+<fa-icon icon="user" [border]="true" a11yRole="presentation" />
 
 <h3>Duotone icons</h3>
-<fa-duotone-icon [icon]="faDummy"></fa-duotone-icon>
+<fa-duotone-icon [icon]="faDummy" />
 <p>Swap layer opacity.</p>
-<fa-duotone-icon [icon]="faDummy" swapOpacity="true"></fa-duotone-icon>
+<fa-duotone-icon [icon]="faDummy" swapOpacity="true" />
 <p>Custom primary or secondary layer opacity.</p>
-<fa-duotone-icon [icon]="faDummy" primaryOpacity="0.7" secondaryOpacity="0.1"></fa-duotone-icon>
+<fa-duotone-icon [icon]="faDummy" primaryOpacity="0.7" secondaryOpacity="0.1" />
 <p>Custom primary or secondary layer color.</p>
-<fa-duotone-icon [icon]="faDummy" primaryColor="red" secondaryColor="blue"></fa-duotone-icon>
+<fa-duotone-icon [icon]="faDummy" primaryColor="red" secondaryColor="blue" />
 
 <h3>Icon with Non-default Style Prefix Using [prefix, iconName]</h3>
 <p><code>icon</code> should be set equal to an array object with two string elements: the prefix and the icon name.</p>
@@ -25,117 +25,108 @@
   Using a string for an icon name also requires that this icon has been added to the library with
   <code>library.add()</code>
 </p>
-<fa-icon [icon]="['far', 'user']"></fa-icon>
+<fa-icon [icon]="['far', 'user']" />
 
 <h3>Icon as Object with non-Default Prefix</h3>
 <p>The icon object knows its own prefix, so the prefix is not specified in this case.</p>
-<fa-icon [icon]="regularUser"></fa-icon>
+<fa-icon [icon]="regularUser" />
 
 <h3>With Mask and Transform</h3>
-<fa-icon [icon]="faCircle" transform="shrink-9 right-4" [mask]="faSquare"></fa-icon>
+<fa-icon [icon]="faCircle" transform="shrink-9 right-4" [mask]="faSquare" />
 
 <h3>Change Size</h3>
-<fa-icon [icon]="faAdjust" size="2x"></fa-icon>
+<fa-icon [icon]="faAdjust" size="2x" />
 
 <h3>Change color</h3>
 
-<p>Using custom style: <fa-icon [icon]="faAdjust" [style.color]="'red'"></fa-icon></p>
-<p>Using custom class: <fa-icon [icon]="faAdjust" class="green-icon"></fa-icon></p>
+<p>Using custom style: <fa-icon [icon]="faAdjust" [style.color]="'red'" /></p>
+<p>Using custom class: <fa-icon [icon]="faAdjust" class="green-icon" /></p>
 
 <h3>Rotate</h3>
 
-<p><fa-icon icon="user" [rotate]="90"></fa-icon></p>
+<p><fa-icon icon="user" [rotate]="90" /></p>
 
-<p><fa-icon icon="user" rotate="45deg"></fa-icon></p>
+<p><fa-icon icon="user" rotate="45deg" /></p>
 
 <h3>Animations</h3>
 
 <button type="button" (click)="isAnimated = !isAnimated">Toggle animations</button>
 
 <p>
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat' : undefined"></fa-icon>&nbsp;
-  <fa-icon
-    [icon]="faHeart"
-    [animation]="isAnimated ? 'beat' : undefined"
-    style="--fa-animation-duration: 0.5s"
-  ></fa-icon
-  >&nbsp;
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat' : undefined" style="--fa-beat-scale: 2"></fa-icon>
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat' : undefined" />&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat' : undefined" style="--fa-animation-duration: 0.5s" />&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat' : undefined" style="--fa-beat-scale: 2" />
 </p>
 
 <p>
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'fade' : undefined"></fa-icon>&nbsp;
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'fade' : undefined" style="--fa-fade-opacity: 0.1"></fa-icon
-  >&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'fade' : undefined" />&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'fade' : undefined" style="--fa-fade-opacity: 0.1" />&nbsp;
 </p>
 
 <p>
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat-fade' : undefined"></fa-icon>&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat-fade' : undefined" />&nbsp;
   <fa-icon
     [icon]="faHeart"
     [animation]="isAnimated ? 'beat-fade' : undefined"
     style="--fa-beat-fade-opacity: 0.1"
-  ></fa-icon
-  >&nbsp;
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat-fade' : undefined" style="--fa-beat-fade-scale: 2"></fa-icon
-  >&nbsp;
+  />&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'beat-fade' : undefined" style="--fa-beat-fade-scale: 2" />&nbsp;
 </p>
 
-<p><fa-icon [icon]="faHeart" [animation]="isAnimated ? 'bounce' : undefined"></fa-icon>&nbsp;</p>
+<p><fa-icon [icon]="faHeart" [animation]="isAnimated ? 'bounce' : undefined" />&nbsp;</p>
 
 <p>
-  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'flip' : undefined"></fa-icon>&nbsp;
+  <fa-icon [icon]="faHeart" [animation]="isAnimated ? 'flip' : undefined" />&nbsp;
   <fa-icon
     [icon]="faHeart"
     [animation]="isAnimated ? 'flip' : undefined"
     style="--fa-flip-x: 1; --fa-flip-y: 0"
-  ></fa-icon
-  >&nbsp;
+  />&nbsp;
 </p>
 
-<p><fa-icon [icon]="faHeart" [animation]="isAnimated ? 'shake' : undefined"></fa-icon>&nbsp;</p>
+<p><fa-icon [icon]="faHeart" [animation]="isAnimated ? 'shake' : undefined" />&nbsp;</p>
 
 <p>
-  <fa-icon [icon]="faCog" [animation]="isAnimated ? 'spin' : undefined"></fa-icon>&nbsp;
-  <fa-icon [icon]="faCog" [animation]="isAnimated ? 'spin-reverse' : undefined"></fa-icon>&nbsp;
-  <fa-icon [icon]="faSpinner" [animation]="isAnimated ? 'spin-pulse' : undefined"></fa-icon>&nbsp;
-  <fa-icon [icon]="faSpinner" [animation]="isAnimated ? 'spin-pulse-reverse' : undefined"></fa-icon>&nbsp;
+  <fa-icon [icon]="faCog" [animation]="isAnimated ? 'spin' : undefined" />&nbsp;
+  <fa-icon [icon]="faCog" [animation]="isAnimated ? 'spin-reverse' : undefined" />&nbsp;
+  <fa-icon [icon]="faSpinner" [animation]="isAnimated ? 'spin-pulse' : undefined" />&nbsp;
+  <fa-icon [icon]="faSpinner" [animation]="isAnimated ? 'spin-pulse-reverse' : undefined" />&nbsp;
 </p>
 
 <p>Slide to turn up the magic.</p>
-<fa-icon [icon]="faMagic" transform="rotate-{{ magicLevel }}"></fa-icon>
+<fa-icon [icon]="faMagic" transform="rotate-{{ magicLevel }}" />
 <input type="range" [value]="magicLevel" (input)="magicLevel = $any($event.target).value" />
 
 <h3>Stack</h3>
 <p>Stack multiple icons into one.</p>
 <fa-stack>
-  <fa-icon [icon]="faCircle" stackItemSize="2x"></fa-icon>
-  <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x"></fa-icon>
+  <fa-icon [icon]="faCircle" stackItemSize="2x" />
+  <fa-icon [icon]="solidFlag" [inverse]="true" stackItemSize="1x" />
 </fa-stack>
 
 <h3>Layers</h3>
 <p>Custom icons created with multiple layers.</p>
 <div>
   <fa-layers [fixedWidth]="true" size="4x">
-    <fa-icon [icon]="faCircle" [style.color]="'Tomato'"></fa-icon>
-    <fa-icon [icon]="faTimes" [inverse]="true" transform="shrink-6"></fa-icon>
+    <fa-icon [icon]="faCircle" [style.color]="'Tomato'" />
+    <fa-icon [icon]="faTimes" [inverse]="true" transform="shrink-6" />
   </fa-layers>
   <fa-layers [fixedWidth]="true" size="4x">
-    <fa-icon [icon]="faSquare"></fa-icon>
-    <fa-icon [icon]="faBatteryQuarter" transform="shrink-8" [style.color]="'Tomato'"></fa-icon>
+    <fa-icon [icon]="faSquare" />
+    <fa-icon [icon]="faBatteryQuarter" transform="shrink-8" [style.color]="'Tomato'" />
   </fa-layers>
   <fa-layers [fixedWidth]="true" size="4x">
-    <fa-icon [icon]="faFighterJet"></fa-icon>
-    <fa-icon [icon]="faCircle" [inverse]="true" transform="shrink-13.8 right-1.8"></fa-icon>
-    <fa-icon [icon]="faEllipsisH" transform="shrink-13 up-6.8 right-2"></fa-icon>
-    <fa-icon [icon]="faEllipsisH" transform="shrink-13 down-6.8 right-2"></fa-icon>
+    <fa-icon [icon]="faFighterJet" />
+    <fa-icon [icon]="faCircle" [inverse]="true" transform="shrink-13.8 right-1.8" />
+    <fa-icon [icon]="faEllipsisH" transform="shrink-13 up-6.8 right-2" />
+    <fa-icon [icon]="faEllipsisH" transform="shrink-13 down-6.8 right-2" />
   </fa-layers>
 </div>
 <p>Using text as one of the layers.</p>
 <div>
   <fa-layers [fixedWidth]="true" size="4x">
-    <fa-icon [icon]="faFlag"></fa-icon>
-    <fa-layers-text title="Fort Awesome" [content]="'Fa'" transform="up-4" [style.font-size]="'0.3em'"></fa-layers-text>
+    <fa-icon [icon]="faFlag" />
+    <fa-layers-text title="Fort Awesome" [content]="'Fa'" transform="up-4" [style.font-size]="'0.3em'" />
   </fa-layers>
 </div>
 
@@ -163,20 +154,20 @@
 
 <div>
   <fa-layers [fixedWidth]="true" size="3x">
-    <fa-icon [icon]="faBell"></fa-icon>
+    <fa-icon [icon]="faBell" />
     <fa-layers-counter
       [position]="selectedPosition"
       [content]="$any(notificationsCounter | number)"
       title="Unread Messages"
-    ></fa-layers-counter>
+    />
   </fa-layers>
 </div>
 
-<app-alternate-prefix></app-alternate-prefix>
+<app-alternate-prefix />
 
 <h3>Fallback icon</h3>
 <p>
   Icon uses a fallback icon when the main icon parameter is not specified. Useful for when the icon is loaded
   asynchronously. If no fallback icon is specified, the icon will not appear. (Not shown in this example.)
 </p>
-<fa-icon [icon]="undefined!"></fa-icon>
+<fa-icon [icon]="undefined!" />

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -69,12 +69,12 @@ export class AppComponent {
     // So in the template, the only way to reference the non-default (fas) icon is to either
     // use the array syntax that specifies [prefix, iconName], like this:
     //
-    // <fa-icon [icon]="['far','user']"></fa-icon>
+    // <fa-icon [icon]="['far','user']" />
     //
     // Or we could make the regularUser object available to the template and simply
     // reference it as an object, like this:
     //
-    // <fa-icon [icon]="regularUser"></fa-icon>
+    // <fa-icon [icon]="regularUser" />
     //
     // You don't specify the prefix in that case, because the icon object knows its own prefix.
     inject(FaIconLibrary).addIcons(faUser, regularUser);

--- a/projects/demo/src/app/testing/explicit-reference.component.ts
+++ b/projects/demo/src/app/testing/explicit-reference.component.ts
@@ -5,7 +5,7 @@ import { faUser } from '@fortawesome/free-solid-svg-icons';
 @Component({
   selector: 'app-explicit-reference',
   imports: [FaIconComponent],
-  template: '<fa-icon [icon]="faUser"></fa-icon>',
+  template: '<fa-icon [icon]="faUser" />',
 })
 export class ExplicitReferenceComponent {
   faUser = faUser;

--- a/projects/demo/src/app/testing/icon-library.component.ts
+++ b/projects/demo/src/app/testing/icon-library.component.ts
@@ -4,6 +4,6 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 @Component({
   selector: 'app-regular-icon-library',
   imports: [FaIconComponent],
-  template: '<fa-icon icon="user"></fa-icon>',
+  template: '<fa-icon icon="user" />',
 })
 export class IconLibraryComponent {}

--- a/src/lib/icon/duotone-icon.component.spec.ts
+++ b/src/lib/icon/duotone-icon.component.spec.ts
@@ -8,7 +8,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -23,7 +23,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()" [swapOpacity]="true"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [swapOpacity]="true" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -38,7 +38,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()" [primaryOpacity]="0.1"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [primaryOpacity]="0.1" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -53,7 +53,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()" [secondaryOpacity]="0.9"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" [secondaryOpacity]="0.9" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -68,7 +68,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()" primaryColor="red"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" primaryColor="red" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -83,7 +83,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faDummy()" secondaryColor="red"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faDummy()" secondaryColor="red" />',
     })
     class HostComponent {
       faDummy = signal(faDummy);
@@ -98,7 +98,7 @@ describe('FaDuotoneIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-duotone-icon [icon]="faUser()"></fa-duotone-icon>',
+      template: '<fa-duotone-icon [icon]="faUser()" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -108,8 +108,8 @@ describe('FaDuotoneIconComponent', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
-          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\"></fa-duotone-icon> " +
-          'or use: <fa-icon icon="user"></fa-icon> instead.',
+          "Check that you specified the correct style: <fa-duotone-icon [icon]=\"['fad', 'user']\" /> " +
+          'or use: <fa-icon icon="user" /> instead.',
       ),
     );
   });

--- a/src/lib/icon/duotone-icon.component.ts
+++ b/src/lib/icon/duotone-icon.component.ts
@@ -57,8 +57,8 @@ export class FaDuotoneIconComponent extends FaIconComponent {
       throw new Error(
         'The specified icon does not appear to be a Duotone icon. ' +
           'Check that you specified the correct style: ' +
-          `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']"></fa-duotone-icon> ` +
-          `or use: <fa-icon icon="${definition.iconName}"></fa-icon> instead.`,
+          `<fa-duotone-icon [icon]="['fad', '${definition.iconName}']" /> ` +
+          `or use: <fa-icon icon="${definition.iconName}" /> instead.`,
       );
     }
 

--- a/src/lib/icon/icon.component.spec.ts
+++ b/src/lib/icon/icon.component.spec.ts
@@ -16,7 +16,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -31,7 +31,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()" [inverse]="isInverse()"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" [inverse]="isInverse()" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -75,7 +75,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" />',
     })
     class HostComponent {
       iconComponent = viewChild(FaIconComponent);
@@ -96,7 +96,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()" a11yRole="presentation"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" a11yRole="presentation" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -111,7 +111,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="undefined"></fa-icon>',
+      template: '<fa-icon [icon]="undefined" />',
     })
     class HostComponent {}
 
@@ -125,7 +125,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="icon | async"></fa-icon>',
+      template: '<fa-icon [icon]="icon | async" />',
     })
     class HostComponent {
       iconSubject = new Subject<IconProp>();
@@ -148,7 +148,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="icon()"></fa-icon>',
+      template: '<fa-icon [icon]="icon()" />',
     })
     class HostComponent {
       iconSubject = new Subject<IconProp>();
@@ -171,7 +171,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()" title="User John Smith"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" title="User John Smith" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -199,7 +199,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: ` <fa-icon [icon]="faUser()" [title]="'User John Smith'"></fa-icon> `,
+      template: ` <fa-icon [icon]="faUser()" [title]="'User John Smith'" /> `,
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -215,7 +215,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user"></fa-icon>',
+      template: '<fa-icon icon="user" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -232,7 +232,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user"></fa-icon>',
+      template: '<fa-icon icon="user" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -251,7 +251,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user"></fa-icon>',
+      template: '<fa-icon icon="user" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -268,7 +268,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user"></fa-icon>',
+      template: '<fa-icon icon="user" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -287,7 +287,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user" [fixedWidth]="fixedWidth()"></fa-icon>',
+      template: '<fa-icon icon="user" [fixedWidth]="fixedWidth()" />',
     })
     class HostComponent {
       fixedWidth = signal(true);
@@ -307,7 +307,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user" [fixedWidth]="fixedWidth()"></fa-icon>',
+      template: '<fa-icon icon="user" [fixedWidth]="fixedWidth()" />',
     })
     class HostComponent {
       fixedWidth = signal(false);
@@ -327,7 +327,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user"></fa-icon>',
+      template: '<fa-icon icon="user" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -344,7 +344,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="circle"></fa-icon>',
+      template: '<fa-icon icon="circle" />',
     })
     class HostComponent {}
 
@@ -358,7 +358,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="undefined"></fa-icon>',
+      template: '<fa-icon [icon]="undefined" />',
     })
     class HostComponent {
       constructor(config: FaConfig) {
@@ -377,7 +377,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon [icon]="faUser()"></fa-icon>',
+      template: '<fa-icon [icon]="faUser()" />',
     })
     class HostComponent {
       faUser = signal(faUser);
@@ -398,7 +398,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-stack><fa-icon [icon]="faCircle()"></fa-icon></fa-stack>',
+      template: '<fa-stack><fa-icon [icon]="faCircle()" />',
     })
     class HostComponent {
       faCircle = signal(faCircle);
@@ -410,7 +410,7 @@ describe('FaIconComponent', () => {
     fixture.detectChanges();
     expect(spy).toHaveBeenCalledWith(
       'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-        'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+        'fa-stack. Example: <fa-icon stackItemSize="2x" />.',
     );
   });
 
@@ -418,7 +418,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user" [rotate]="90"></fa-icon>',
+      template: '<fa-icon icon="user" [rotate]="90" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -435,7 +435,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user" rotate="90"></fa-icon>',
+      template: '<fa-icon icon="user" rotate="90" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {
@@ -452,7 +452,7 @@ describe('FaIconComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-icon icon="user" rotate="45deg"></fa-icon>',
+      template: '<fa-icon icon="user" rotate="45deg" />',
     })
     class HostComponent {
       constructor(iconLibrary: FaIconLibrary) {

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -101,7 +101,7 @@ export class FaIconComponent {
     if (this.stack != null && this.stackItem == null) {
       console.error(
         'FontAwesome: fa-icon and fa-duotone-icon elements must specify stackItemSize attribute when wrapped into ' +
-          'fa-stack. Example: <fa-icon stackItemSize="2x"></fa-icon>.',
+          'fa-stack. Example: <fa-icon stackItemSize="2x" />.',
       );
     }
   }

--- a/src/lib/layers/layers-counter.component.spec.ts
+++ b/src/lib/layers/layers-counter.component.spec.ts
@@ -8,7 +8,7 @@ describe('FaLayersCounterComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-layers-counter [content]="'Test'"></fa-layers-counter>
+          <fa-layers-counter [content]="'Test'" />
         </fa-layers>
       `,
     })
@@ -23,7 +23,7 @@ describe('FaLayersCounterComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: `<fa-layers-counter content="300"></fa-layers-counter> `,
+      template: `<fa-layers-counter content="300" /> `,
     })
     class HostComponent {}
 
@@ -38,7 +38,7 @@ describe('FaLayersCounterComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-layers-counter [position]="'bottom-left'" [content]="'Test'"></fa-layers-counter>
+          <fa-layers-counter [position]="'bottom-left'" [content]="'Test'" />
         </fa-layers>
       `,
     })

--- a/src/lib/layers/layers-text.component.spec.ts
+++ b/src/lib/layers/layers-text.component.spec.ts
@@ -8,7 +8,7 @@ describe('FaLayersTextComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-layers-text [content]="'Test'"></fa-layers-text>
+          <fa-layers-text [content]="'Test'" />
         </fa-layers>
       `,
     })
@@ -23,7 +23,7 @@ describe('FaLayersTextComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: `<fa-layers-text content="Test"></fa-layers-text> `,
+      template: `<fa-layers-text content="Test" /> `,
     })
     class HostComponent {}
 

--- a/src/lib/layers/layers.component.spec.ts
+++ b/src/lib/layers/layers.component.spec.ts
@@ -13,9 +13,9 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-icon [icon]="faUser()"></fa-icon>
-          <fa-icon [icon]="faCoffee()"></fa-icon>
-          <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
+          <fa-icon [icon]="faUser()" />
+          <fa-icon [icon]="faCoffee()" />
+          <fa-layers-text [content]="'User with coffee'" />
         </fa-layers>
       `,
     })
@@ -35,9 +35,9 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers size="2x">
-          <fa-icon [icon]="faUser()"></fa-icon>
-          <fa-icon [icon]="faCoffee()"></fa-icon>
-          <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
+          <fa-icon [icon]="faUser()" />
+          <fa-icon [icon]="faCoffee()" />
+          <fa-layers-text [content]="'User with coffee'" />
         </fa-layers>
       `,
     })
@@ -55,7 +55,7 @@ describe('FaLayersComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-layers [fixedWidth]="true"></fa-layers>',
+      template: '<fa-layers [fixedWidth]="true" />',
     })
     class HostComponent {}
 
@@ -70,7 +70,7 @@ describe('FaLayersComponent', () => {
     @Component({
       selector: 'fa-host',
       standalone: false,
-      template: '<fa-layers></fa-layers>',
+      template: '<fa-layers />',
     })
     class HostComponent {}
 
@@ -87,9 +87,9 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers [fixedWidth]="false">
-          <fa-icon [icon]="faUser()"></fa-icon>
-          <fa-icon [icon]="faCoffee()"></fa-icon>
-          <fa-layers-text [content]="'User with coffee'"></fa-layers-text>
+          <fa-icon [icon]="faUser()" />
+          <fa-icon [icon]="faCoffee()" />
+          <fa-layers-text [content]="'User with coffee'" />
         </fa-layers>
       `,
     })
@@ -110,12 +110,12 @@ describe('FaLayersComponent', () => {
       selector: 'fa-host',
       standalone: false,
       template: `
-        <fa-layers class="custom-class" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
-        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
-        <fa-layers [ngClass]="{ 'custom-class': true }" [fixedWidth]="fixedWidth()" [size]="size()"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" class="custom-class"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [class.custom-class]="true"></fa-layers>
-        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [ngClass]="{ 'custom-class': true }"></fa-layers>
+        <fa-layers class="custom-class" [fixedWidth]="fixedWidth()" [size]="size()" />
+        <fa-layers [class.custom-class]="true" [fixedWidth]="fixedWidth()" [size]="size()" />
+        <fa-layers [ngClass]="{ 'custom-class': true }" [fixedWidth]="fixedWidth()" [size]="size()" />
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" class="custom-class" />
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [class.custom-class]="true" />
+        <fa-layers [fixedWidth]="fixedWidth()" [size]="size()" [ngClass]="{ 'custom-class': true }" />
       `,
     })
     class HostComponent {
@@ -141,8 +141,8 @@ describe('FaLayersComponent', () => {
       standalone: false,
       template: `
         <fa-layers>
-          <fa-duotone-icon [icon]="faDummy()"></fa-duotone-icon>
-          <fa-layers-text [content]="'Dummy'"></fa-layers-text>
+          <fa-duotone-icon [icon]="faDummy()" />
+          <fa-layers-text [content]="'Dummy'" />
         </fa-layers>
       `,
     })
@@ -162,8 +162,8 @@ describe('FaLayersComponent', () => {
       template: `
         <fa-layers>
           <ng-container>
-            <fa-icon [icon]="faUser()"></fa-icon>
-            <fa-layers-text [content]="'Dummy'"></fa-layers-text>
+            <fa-icon [icon]="faUser()" />
+            <fa-layers-text [content]="'Dummy'" />
           </ng-container>
         </fa-layers>
       `,

--- a/src/lib/layers/layers.component.ts
+++ b/src/lib/layers/layers.component.ts
@@ -8,7 +8,7 @@ import { ensureCss } from '../shared/utils/css';
  */
 @Component({
   selector: 'fa-layers',
-  template: `<ng-content></ng-content>`,
+  template: `<ng-content />`,
   host: {
     '[class]': 'classes()',
   },

--- a/src/lib/stack/stack-item-size.directive.spec.ts
+++ b/src/lib/stack/stack-item-size.directive.spec.ts
@@ -23,8 +23,8 @@ describe('FaStackItemSizeDirective', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x" />
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x" />
         </fa-stack>
       `,
     })
@@ -45,8 +45,8 @@ describe('FaStackItemSizeDirective', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser()" [inverse]="true" size="1x" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x" />
+          <fa-icon [icon]="faUser()" [inverse]="true" size="1x" stackItemSize="1x" />
         </fa-stack>
       `,
     })

--- a/src/lib/stack/stack.component.spec.ts
+++ b/src/lib/stack/stack.component.spec.ts
@@ -9,8 +9,8 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x" />
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x" />
         </fa-stack>
       `,
     })
@@ -30,8 +30,8 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack>
-          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
-          <fa-duotone-icon [icon]="dummyDuotoneIcon()" [inverse]="true" stackItemSize="1x"></fa-duotone-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x" />
+          <fa-duotone-icon [icon]="dummyDuotoneIcon()" [inverse]="true" stackItemSize="1x" />
         </fa-stack>
       `,
     })
@@ -51,8 +51,8 @@ describe('FaStackComponent', () => {
       standalone: false,
       template: `
         <fa-stack size="2x">
-          <fa-icon [icon]="faCircle()" stackItemSize="2x"></fa-icon>
-          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x"></fa-icon>
+          <fa-icon [icon]="faCircle()" stackItemSize="2x" />
+          <fa-icon [icon]="faUser()" [inverse]="true" stackItemSize="1x" />
         </fa-stack>
       `,
     })

--- a/src/lib/stack/stack.component.ts
+++ b/src/lib/stack/stack.component.ts
@@ -3,7 +3,7 @@ import { SizeProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
   selector: 'fa-stack',
-  template: `<ng-content></ng-content>`,
+  template: `<ng-content />`,
   host: {
     '[class]': 'classes()',
   },

--- a/testing/src/testing.module.spec.ts
+++ b/testing/src/testing.module.spec.ts
@@ -8,7 +8,7 @@ import { FontAwesomeTestingModule } from './testing.module';
 @Component({
   selector: 'fa-host',
   standalone: false,
-  template: '<fa-icon icon="someicon"></fa-icon>',
+  template: '<fa-icon icon="someicon" />',
 })
 class HostComponent {}
 


### PR DESCRIPTION
Self-closing tags have been supported since [Angular 16](https://blog.angular.dev/angular-v16-is-here-4d7a28ec680d#7065) and improve readability when Angular components without content are used inside a template.

Since most FontAwesome components do not support content projection, there's no use for the space between the opening and closing tags of the elements.

`<fa-icon [icon]="faCoffee"></fa-icon>` -> `<fa-icon [icon]="faCoffee" />`

Using the self-closing tag on `<fa-icon />` clearly communicates that the element doesn't expect any content between the opening and closing tags.

---

This PR changes most the documentation and examples to use the self-closing tags.

The only files I left as-is are all but the latest file in the `upgrading/` folder, since those can be referenced with Angular versions below 16.